### PR TITLE
chore(turnstile): remove secret key path

### DIFF
--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -1,7 +1,6 @@
 import type { DefineNuxtConfig } from 'nuxt/config'
 
 import { RELEASE_NAME, SITE_URL } from '../../node'
-import { SITE_NAME } from '../../shared/utils/constants'
 import { cookieControlConfig } from './cookieControl'
 import { i18nConfig } from './i18n'
 import { pwaConfig } from './pwa'
@@ -51,11 +50,6 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   },
   ...i18nConfig,
   ...pwaConfig,
-  turnstile: {
-    secretKeyPath: process.env.NUXT_PUBLIC_SITE_URL
-      ? `/run/secrets/${SITE_NAME}_turnstile-key`
-      : undefined,
-  },
   linkChecker: {
     failOnError: true,
   },


### PR DESCRIPTION
### 📚 Description

This configuration option is not used anymore and leads to a warning:

![image](https://github.com/user-attachments/assets/1af7f46e-2780-43cf-a11c-6ab74a791d1a)

cc @huzaifaedhi22 
### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
