### PR TITLE
ci(docker): specify service dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 
+# <DEPENDENCIES>
+FROM ghcr.io/maevsi/sqitch:6
+# </DEPENDENCIES>
+
 #############
 # Create base image.
 


### PR DESCRIPTION
### 📚 Description

To specify compatible versions of other services, I introduce a "dependency" section at the top of the Dockerfile. These dependencies are not used by any stage below so they are not downloaded at build time. Renovate should notice breaking changes should allow for basic cross-language dependency management.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
