### PR TITLE
feat(platform): consent to optional cookies through native ios framework

### DIFF
--- a/src/app/app.vue
+++ b/src/app/app.vue
@@ -30,7 +30,7 @@
       <NuxtPage />
     </NuxtLayout>
     <VitePwaManifest />
-    <ClientOnly>
+    <ClientOnly v-if="!isAppIos">
       <!-- TODO: render server side too when styling is improved (https://github.com/dargmuesli/nuxt-cookie-control/discussions/228)  -->
       <CookieControl :locale="locale" />
     </ClientOnly>
@@ -55,7 +55,7 @@ import supportedBrowsers from '~/supportedBrowsers'
 
 const i18n = useI18n()
 const { $pwa } = useNuxtApp()
-const { isApp } = usePlatform()
+const { isApp, isAppIos } = usePlatform()
 const runtimeConfig = useRuntimeConfig()
 const locale = i18n.locale as WritableComputedRef<Locale>
 const { t } = i18n

--- a/src/app/composables/platform.ts
+++ b/src/app/composables/platform.ts
@@ -11,9 +11,15 @@ export const usePlatform = () => {
       ? ['android', 'ios', 'iOS App Store'].includes(platform.value)
       : undefined,
   )
+  const isAppIos = ref<boolean | undefined>(
+    platform.value
+      ? ['ios', 'iOS App Store'].includes(platform.value)
+      : undefined,
+  )
 
   return {
     isApp,
+    isAppIos,
     platform,
   }
 }


### PR DESCRIPTION
### 📚 Description

Consent for optional cookies should be set using the native ios tracking framework.

TODO:
- consent to optional cookies through native ios framework

cc @huzaifaedhi22 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
