### PR TITLE
feat(pages): prefer route rules for robots configuration

### DIFF
--- a/src/app/pages/account/password/reset/index.vue
+++ b/src/app/pages/account/password/reset/index.vue
@@ -9,6 +9,10 @@
 </template>
 
 <script setup lang="ts">
+defineRouteRules({
+  robots: false,
+})
+
 // page
 const { t } = useI18n()
 const title = t('title')

--- a/src/app/pages/account/verify/index.vue
+++ b/src/app/pages/account/verify/index.vue
@@ -16,6 +16,10 @@
 <script setup lang="ts">
 import { useAccountEmailAddressVerificationMutation } from '~~/gql/documents/mutations/account/accountEmailAddressVerification'
 
+defineRouteRules({
+  robots: false,
+})
+
 // page
 const { t } = useI18n()
 const title = t('title')

--- a/src/app/pages/session/edit/[id]/index.vue
+++ b/src/app/pages/session/edit/[id]/index.vue
@@ -217,6 +217,10 @@ import type { RouteNamedMap } from 'vue-router/auto-routes'
 
 const ROUTE_NAME: keyof RouteNamedMap = 'session-edit-id___en'
 
+defineRouteRules({
+  robots: false,
+})
+
 const { t } = useI18n()
 const cookieControl = useCookieControl()
 const localePath = useLocalePath()

--- a/src/app/pages/🫖/index.vue
+++ b/src/app/pages/🫖/index.vue
@@ -3,6 +3,10 @@
 </template>
 
 <script setup lang="ts">
+defineRouteRules({
+  robots: false,
+})
+
 throw createError({
   statusCode: 418,
 })

--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -6,14 +6,6 @@ import { i18nConfig } from './i18n'
 import { pwaConfig } from './pwa'
 import { securityConfig } from './security'
 
-const ROBOTS_DISALLOW = [
-  '/%F0%9F%AB%96',
-  '/account/password/reset',
-  '/account/verify',
-  '/session/edit',
-  '/session/view',
-]
-
 export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   colorMode: {
     classSuffix: '',
@@ -58,9 +50,6 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   linkChecker: {
     failOnError: true,
   },
-  robots: {
-    disallow: ROBOTS_DISALLOW,
-  },
   ...securityConfig,
   sentry: {
     sourceMapsUploadOptions: {
@@ -80,6 +69,5 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   },
   sitemap: {
     credits: false,
-    exclude: ROBOTS_DISALLOW,
   },
 }

--- a/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-Mobile-Chrome-linux.txt
+++ b/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-Mobile-Chrome-linux.txt
@@ -1,15 +1,6 @@
 # START nuxt-robots (indexable)
 User-agent: *
-Disallow: /%F0%9F%AB%96
-Disallow: /de/%F0%9F%AB%96
-Disallow: /account/password/reset
-Disallow: /de/account/password/reset
-Disallow: /account/verify
-Disallow: /de/account/verify
-Disallow: /session/edit
-Disallow: /de/session/edit
-Disallow: /session/view
-Disallow: /de/session/view
+Disallow: 
 
 Sitemap: http://localhost:3001/sitemap_index.xml
 # END nuxt-robots

--- a/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-Mobile-Safari-linux.txt
+++ b/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-Mobile-Safari-linux.txt
@@ -1,15 +1,6 @@
 # START nuxt-robots (indexable)
 User-agent: *
-Disallow: /%F0%9F%AB%96
-Disallow: /de/%F0%9F%AB%96
-Disallow: /account/password/reset
-Disallow: /de/account/password/reset
-Disallow: /account/verify
-Disallow: /de/account/verify
-Disallow: /session/edit
-Disallow: /de/session/edit
-Disallow: /session/view
-Disallow: /de/session/view
+Disallow: 
 
 Sitemap: http://localhost:3001/sitemap_index.xml
 # END nuxt-robots

--- a/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-chromium-linux.txt
+++ b/tests/e2e/specs/server/robots.spec.ts-snapshots/robots-txt-content-chromium-linux.txt
@@ -1,15 +1,6 @@
 # START nuxt-robots (indexable)
 User-agent: *
-Disallow: /%F0%9F%AB%96
-Disallow: /de/%F0%9F%AB%96
-Disallow: /account/password/reset
-Disallow: /de/account/password/reset
-Disallow: /account/verify
-Disallow: /de/account/verify
-Disallow: /session/edit
-Disallow: /de/session/edit
-Disallow: /session/view
-Disallow: /de/session/view
+Disallow: 
 
 Sitemap: http://localhost:3001/sitemap_index.xml
 # END nuxt-robots

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-Mobile-Chrome-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-Mobile-Chrome-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/de/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/de/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/de/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-Mobile-Safari-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-Mobile-Safari-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/de/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/de/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/de/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-chromium-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-de-chromium-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/de/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/de/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/de/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-Mobile-Chrome-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-Mobile-Chrome-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-Mobile-Safari-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-Mobile-Safari-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>

--- a/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-chromium-linux.xml
+++ b/tests/e2e/specs/server/sitemap.spec.ts-snapshots/sitemap-content-en-chromium-linux.xml
@@ -97,6 +97,12 @@
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/session/create" />
     </url>
     <url>
+        <loc>http://localhost:3001/account/verify/create</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/verify/create" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/verify/create" />
+    </url>
+    <url>
         <loc>http://localhost:3001/docs/legal/attributions</loc>
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/docs/legal/attributions" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/docs/legal/attributions" />
@@ -131,5 +137,11 @@
         <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/event/ingest/url" />
         <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/event/ingest/url" />
+    </url>
+    <url>
+        <loc>http://localhost:3001/account/password/reset/request</loc>
+        <xhtml:link rel="alternate" hreflang="de" href="http://localhost:3001/de/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="en" href="http://localhost:3001/account/password/reset/request" />
+        <xhtml:link rel="alternate" hreflang="x-default" href="http://localhost:3001/account/password/reset/request" />
     </url>
 </urlset>


### PR DESCRIPTION
### 📚 Description

Now that we use route rules, we can drop the hardcoded path excludes for `robots.txt` and sitemap.
Crawlers can access any page, but are instructed to ignore the ones disabled.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
