### PR TITLE
refactor(components): integrate shadcn-nuxt's form into radio input

### DIFF
--- a/src/app/components/app/radio/AppRadioGroup.vue
+++ b/src/app/components/app/radio/AppRadioGroup.vue
@@ -1,16 +1,19 @@
 <template>
   <RadioGroup :class="props.class" v-bind="forwarded">
-    <FormRadioGroupItem
+    <component
+      :is="props.isForm ? FormRadioGroupItem : AppRadioGroupItem"
       v-for="item in props.items"
       :key="item.value"
+      class="flex items-center gap-3 p-1"
       :value="item.value"
     >
       {{ item.label }}
-    </FormRadioGroupItem>
+    </component>
   </RadioGroup>
 </template>
 
 <script setup lang="ts">
+import { FormRadioGroupItem, AppRadioGroupItem } from '#components'
 import {
   useForwardPropsEmits,
   type RadioGroupRootEmits,
@@ -20,6 +23,7 @@ import type { HTMLAttributes } from 'vue'
 
 const props = defineProps<
   {
+    isForm?: boolean
     items: {
       value: string
       label: string
@@ -29,7 +33,7 @@ const props = defineProps<
 const emits = defineEmits<RadioGroupRootEmits>()
 
 const delegatedProps = computed(() => {
-  const { class: _, ...delegated } = props
+  const { class: _, isForm: _isForm, items: _items, ...delegated } = props
 
   return delegated
 })

--- a/src/app/components/app/radio/AppRadioGroupItem.vue
+++ b/src/app/components/app/radio/AppRadioGroupItem.vue
@@ -1,18 +1,18 @@
 <template>
-  <FormItem>
-    <FormControl>
-      <RadioGroupItem :value />
-    </FormControl>
-    <FormLabel>
+  <div>
+    <RadioGroupItem :id="templateIdLabel" :value />
+    <Label :for="templateIdLabel">
       <TypographySubtitleSmall>
         <slot />
       </TypographySubtitleSmall>
-    </FormLabel>
-  </FormItem>
+    </Label>
+  </div>
 </template>
 
 <script setup lang="ts">
 const { value } = defineProps<{
   value: string
 }>()
+
+const templateIdLabel = useId()
 </script>

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -94,7 +94,7 @@
         :value="v$.visibility"
         @input="form.visibility = $event as EventVisibility"
       >
-        <FormRadioGroup
+        <AppRadioGroup
           :default-value="v$.visibility.$model"
           :items="[
             { label: t('visibilityPublic'), value: EventVisibility.Public },

--- a/src/app/pages/session/edit/[id]/color-scheme.vue
+++ b/src/app/pages/session/edit/[id]/color-scheme.vue
@@ -2,13 +2,13 @@
   <div>
     <LayoutPageTitle :title />
     <ColorScheme>
-      <FormRadioGroup
+      <AppRadioGroup
         :default-value="colorMode.preference"
         :items="colorSchemes"
         @update:model-value="(value) => (colorMode.preference = value)"
       />
       <template #placeholder>
-        <FormRadioGroup :items="colorSchemes" />
+        <AppRadioGroup :items="colorSchemes" />
       </template>
     </ColorScheme>
   </div>

--- a/src/app/pages/session/edit/[id]/language.vue
+++ b/src/app/pages/session/edit/[id]/language.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <LayoutPageTitle :title />
-    <FormRadioGroup
+    <AppRadioGroup
       :default-value="locale"
       :items="languages"
       @update:model-value="onI18nChange"


### PR DESCRIPTION
### 📚 Description

Refactors the current radio input to a non-form naming scheme and adds a new form variant of it.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
