### PR TITLE
chore(utils): make api computation readonly

### DIFF
--- a/src/app/components/app/AppForm.vue
+++ b/src/app/components/app/AppForm.vue
@@ -52,7 +52,7 @@ import type { BaseValidation } from '@vuelidate/core'
 
 const { errors, errorsPgIds, form, formClass, isButtonHidden, submitName } =
   defineProps<{
-    errors?: BackendError[]
+    errors?: Readonly<BackendError[]>
     errorsPgIds?: Record<string, string>
     form: BaseValidation
     formClass?: string

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -11,22 +11,24 @@ export const getApiData = <
 >(
   queries?: Array<T | undefined>,
 ) => {
-  const apiData = computed(() => ({
-    data: (queries || []).reduce(
-      (p, c) => ({ ...p, ...c?.data.value }),
-      {} as NonNullable<
-        UnionToIntersection<NonNullable<ArrayElement<T[]>['data']['value']>>
-      >,
-    ),
-    errors: (queries || []).reduce(
-      (p, c) => (c?.error.value ? [...p, c.error.value as BackendError] : p),
-      [] as BackendError[],
-    ),
-    isFetching: (queries || []).reduce(
-      (p, c) => p || c?.fetching.value || false,
-      false,
-    ),
-  }))
+  const apiData = computed(() =>
+    readonly({
+      data: (queries || []).reduce(
+        (p, c) => ({ ...p, ...c?.data.value }),
+        {} as NonNullable<
+          UnionToIntersection<NonNullable<ArrayElement<T[]>['data']['value']>>
+        >,
+      ),
+      errors: (queries || []).reduce(
+        (p, c) => (c?.error.value ? [...p, c.error.value as BackendError] : p),
+        [] as BackendError[],
+      ),
+      isFetching: (queries || []).reduce(
+        (p, c) => p || c?.fetching.value || false,
+        false,
+      ),
+    }),
+  )
 
   watch(
     () => apiData.value.errors,

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -11,22 +11,19 @@ export const getApiData = <
 >(
   queries?: Array<T | undefined>,
 ) => {
+  const queriesSafe = queries ?? []
   const apiData = computed(() =>
     readonly({
-      data: (queries || []).reduce(
+      data: queriesSafe.reduce(
         (p, c) => ({ ...p, ...c?.data.value }),
         {} as NonNullable<
           UnionToIntersection<NonNullable<ArrayElement<T[]>['data']['value']>>
         >,
       ),
-      errors: (queries || []).reduce(
-        (p, c) => (c?.error.value ? [...p, c.error.value as BackendError] : p),
-        [] as BackendError[],
+      errors: queriesSafe.flatMap((query) =>
+        query?.error.value ? [query.error.value as BackendError] : [],
       ),
-      isFetching: (queries || []).reduce(
-        (p, c) => p || c?.fetching.value || false,
-        false,
-      ),
+      isFetching: queriesSafe.some((query) => query?.fetching.value),
     }),
   )
 

--- a/src/shared/utils/api.ts
+++ b/src/shared/utils/api.ts
@@ -1,5 +1,5 @@
 export const getCombinedErrorMessages = (
-  errors: BackendError[],
+  errors: Readonly<BackendError[]>,
   pgIds?: Record<string, string>,
 ) => {
   const errorMessages: string[] = []


### PR DESCRIPTION
### 📚 Description

The api utility's return value should not be modified externally.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
