### PR TITLE
refactor(composables): extract named stepper

### DIFF
--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -1,15 +1,15 @@
 <template>
   <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
-    <AppStep v-slot="attributes" :is-active="index === 0">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
       <EventReportForm
         ref="form"
         v-bind="attributes"
         :account-id
         :event
-        @submit-success="index++"
+        @submit-success="step === 'reportConfirmation'"
       />
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 1">
+    <AppStep v-slot="attributes" :is-active="step === 'reportConfirmation'">
       <div v-bind="attributes" class="text-center">
         {{
           t('contentReportConfirmation', {
@@ -18,7 +18,7 @@
         }}
       </div>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 2">
+    <AppStep v-slot="attributes" :is-active="step === 'blockConfirmation'">
       <div v-bind="attributes" class="text-center">
         {{
           t('contentBlockConfirmation', {
@@ -28,24 +28,24 @@
       </div>
     </AppStep>
     <template #title>
-      <AppStep v-slot="attributes" :is-active="index === 0">
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
         <span v-bind="attributes">
           {{ t('titleReport') }}
         </span>
       </AppStep>
-      <AppStep v-slot="attributes" :is-active="index === 1">
+      <AppStep v-slot="attributes" :is-active="step === 'reportConfirmation'">
         <span v-bind="attributes">
           {{ t('titleReportConfirmation') }}
         </span>
       </AppStep>
-      <AppStep v-slot="attributes" :is-active="index === 2">
+      <AppStep v-slot="attributes" :is-active="step === 'blockConfirmation'">
         <span v-bind="attributes">
           {{ t('titleBlockConfirmation') }}
         </span>
       </AppStep>
     </template>
     <template #footer>
-      <AppStep v-slot="attributes" :is-active="index === 0">
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('buttonReportSubmit')"
@@ -64,7 +64,7 @@
           </ButtonColored>
         </DrawerClose>
       </AppStep>
-      <AppStep v-slot="attributes" :is-active="index === 1">
+      <AppStep v-slot="attributes" :is-active="step === 'reportConfirmation'">
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('buttonReportConfirmationBlock')"
@@ -79,7 +79,7 @@
           </ButtonColored>
         </DrawerClose>
       </AppStep>
-      <AppStep v-slot="attributes" :is-active="index === 2">
+      <AppStep v-slot="attributes" :is-active="step === 'blockConfirmation'">
         <DrawerClose v-bind="attributes" as-child>
           <ButtonColored
             :aria-label="t('buttonBlockConfirmation')"
@@ -113,10 +113,12 @@ const isOpen = defineModel<boolean>()
 const open = () => (isOpen.value = true)
 
 // stepper
-const index = ref(0)
+const { step } = useStepper<
+  'default' | 'reportConfirmation' | 'blockConfirmation'
+>()
 const onAnimationEnd = (isOpen: boolean) => {
   if (isOpen) return
-  index.value = 0
+  step.value = 'default'
 }
 
 // block
@@ -153,7 +155,7 @@ const blockOrganizer = async () => {
     return
   }
 
-  index.value++
+  step.value = 'blockConfirmation'
 }
 const backToDashboard = async () =>
   await navigateTo(

--- a/src/app/composables/stepper.ts
+++ b/src/app/composables/stepper.ts
@@ -1,0 +1,54 @@
+export const useStepper = <T extends string>(options?: { initial?: T }) => {
+  const { initial = 'default' as T } = options || {}
+  const _step = ref<T>(initial)
+
+  const error = ref<Error>()
+  const step = computed<'error' | T>({
+    get: () => (error.value ? 'error' : _step.value),
+    set: (value) => (_step.value = value),
+  })
+
+  return {
+    error,
+    step,
+  }
+}
+
+export const useStepperPage = <T extends string>({
+  initial = 'default' as T,
+  steps,
+}: {
+  initial?: T
+  steps: {
+    default: {
+      title?: string
+    }
+    error?: {
+      title: string
+    }
+  } & {
+    [K in T]: {
+      title?: string
+      previous?: T
+    }
+  }
+}) => {
+  const { step, error } = useStepper({
+    initial,
+  })
+  const { t } = useI18n()
+
+  const title = computed(
+    () =>
+      steps[step.value].title ??
+      (step.value === 'error' ? t('globalError') : steps[initial].title),
+  )
+  const previous = computed(() => steps[step.value].previous)
+
+  return {
+    error,
+    previous,
+    step,
+    title,
+  }
+}

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -4,33 +4,33 @@
       <span :id="templateIdTitle">
         {{ title }}
       </span>
-      <template v-if="[1, 2].includes(index)" #back>
-        <ButtonIcon :aria-label="t('back')" @click="index--">
+      <template v-if="previous" #back>
+        <ButtonIcon :aria-label="t('back')" @click="step = previous">
           <AppIconBack />
         </ButtonIcon>
       </template>
     </LayoutTopBar>
-    <AppStep v-slot="attributes" :is-active="index === 0">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
       <LayoutPage v-bind="attributes">
         <FormAccountRegistration
           ref="form"
-          @submit="index++"
-          @success="index++"
+          @submit="step = 'terms'"
+          @success="step = 'success'"
         />
         <ContentLegalFooter />
       </LayoutPage>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 1">
+    <AppStep v-slot="attributes" :is-active="step === 'terms'">
       <AccountLegalConsent
         v-bind="attributes"
         :disabled="!legalTermId"
         :label="t('agreeTerms')"
-        @agreement="index++"
+        @agreement="step = 'privacy'"
       >
         <ContentLegalTerms @id="legalTermId = $event" />
       </AccountLegalConsent>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 2">
+    <AppStep v-slot="attributes" :is-active="step === 'privacy'">
       <AccountLegalConsent
         v-bind="attributes"
         :label="t('agreePrivacy')"
@@ -39,7 +39,7 @@
         <Content path="privacy-consent" />
       </AccountLegalConsent>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 3">
+    <AppStep v-slot="attributes" :is-active="step === 'success'">
       <LayoutPage v-bind="attributes">
         <LayoutPageResult type="success">
           <template #description>
@@ -62,8 +62,6 @@
 </template>
 
 <script setup lang="ts">
-import { consola } from 'consola'
-
 definePageMeta({
   layout: 'plain',
 })
@@ -75,21 +73,25 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const index = ref(0)
-const title = computed(() => {
-  switch (index.value) {
-    case 0:
-      return t('titleForm')
-    case 1:
-      return t('titleTerms')
-    case 2:
-      return t('titlePrivacy')
-    case 3:
-      return t('titleVerification')
-    default:
-      consola.error('Unexpected account flow state')
-      return ''
-  }
+const { step, title, previous } = useStepperPage<
+  'default' | 'terms' | 'privacy' | 'success'
+>({
+  steps: {
+    default: {
+      title: t('titleForm'),
+    },
+    privacy: {
+      title: t('titlePrivacy'),
+      previous: 'terms',
+    },
+    success: {
+      title: t('titleVerification'),
+    },
+    terms: {
+      title: t('titleTerms'),
+      previous: 'default',
+    },
+  },
 })
 
 // page

--- a/src/app/pages/account/password/reset/index.vue
+++ b/src/app/pages/account/password/reset/index.vue
@@ -4,7 +4,7 @@
       <!-- TODO: replace with h1 once unstyled -->
       <span :id="templateIdTitle">{{ title }}</span>
     </LayoutTopBar>
-    <AppStep v-slot="attributes" :is-active="index === 0">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
       <LayoutPage v-bind="attributes">
         <TypographyH3 class="text-center">
           {{ t('instructionsNew') }}
@@ -15,7 +15,7 @@
             ref="form"
             class="w-full max-w-md"
             :code="route.query.code"
-            @success="index++"
+            @success="step = 'success'"
           />
         </div>
         <template #bottom>
@@ -29,7 +29,7 @@
         </template>
       </LayoutPage>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 1">
+    <AppStep v-slot="attributes" :is-active="step === 'success'">
       <LayoutPage v-bind="attributes">
         <LayoutPageResult type="success">
           <template #description>
@@ -84,7 +84,7 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const index = ref(0)
+const { step } = useStepper<'default' | 'success'>()
 </script>
 
 <i18n lang="yaml">

--- a/src/app/pages/account/password/reset/request.vue
+++ b/src/app/pages/account/password/reset/request.vue
@@ -2,7 +2,7 @@
   <section :aria-labelledby="templateIdTitle" class="flex flex-1 flex-col">
     <LayoutTopBar>
       <span :id="templateIdTitle">{{ title }}</span>
-      <template v-if="[0].includes(index)" #close>
+      <template v-if="['default'].includes(step)" #close>
         <ButtonIcon
           :aria-label="t('iconAltClose')"
           @click="navigateTo(localePath('session-create'))"
@@ -11,7 +11,7 @@
         </ButtonIcon>
       </template>
     </LayoutTopBar>
-    <AppStep v-slot="attributes" :is-active="index === 0">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
       <LayoutPage v-bind="attributes">
         <TypographyH3 class="text-center">
           {{ t('instructionsRequest') }}
@@ -20,7 +20,7 @@
           <FormAccountPasswordResetRequest
             ref="form"
             class="w-full max-w-md"
-            @success="index++"
+            @success="step = 'success'"
           />
         </div>
         <template #bottom>
@@ -34,7 +34,7 @@
         </template>
       </LayoutPage>
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 1">
+    <AppStep v-slot="attributes" :is-active="step === 'success'">
       <LayoutPage v-bind="attributes">
         <LayoutPageResult type="success">
           <template #description>
@@ -66,7 +66,7 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const index = ref(0)
+const { step } = useStepper<'default' | 'success'>()
 </script>
 
 <i18n lang="yaml">

--- a/src/app/pages/early-bird/create.vue
+++ b/src/app/pages/early-bird/create.vue
@@ -4,24 +4,24 @@
       <span :id="templateIdTitle">
         {{ title }}
       </span>
-      <template v-if="[1].includes(index)" #back>
-        <ButtonIcon :aria-label="t('back')" @click="index--">
+      <template v-if="previous" #back>
+        <ButtonIcon :aria-label="t('back')" @click="step = previous">
           <AppIconBack />
         </ButtonIcon>
       </template>
-      <template v-if="[0, 1].includes(index)" #close>
+      <template v-if="['default', 'form'].includes(step)" #close>
         <ButtonIcon :aria-label="t('iconAltClose')" @click="store.navigateBack">
           <AppIconClose />
         </ButtonIcon>
       </template>
     </LayoutTopBar>
-    <AppStep v-slot="attributes" :is-active="index === 0">
-      <EarlyBirdWelcome v-bind="attributes" @next="index++" />
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <EarlyBirdWelcome v-bind="attributes" @next="step = 'form'" />
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 1">
-      <EarlyBirdForm v-bind="attributes" @next="index++" />
+    <AppStep v-slot="attributes" :is-active="step === 'form'">
+      <EarlyBirdForm v-bind="attributes" @next="step = 'submission'" />
     </AppStep>
-    <AppStep v-slot="attributes" :is-active="index === 2">
+    <AppStep v-slot="attributes" :is-active="step === 'submission'">
       <EarlyBirdSubmission v-bind="attributes" />
     </AppStep>
   </section>
@@ -34,10 +34,6 @@ definePageMeta({
 
 const { t } = useI18n()
 const templateIdTitle = useId()
-
-// page
-const title = t('title')
-useHeadDefault({ title })
 
 // validation
 const store = useStore()
@@ -55,7 +51,22 @@ if (!store.signedInUsername) {
 }
 
 // stepper
-const index = ref(0)
+const { step, previous, title } = useStepperPage<
+  'default' | 'form' | 'submission'
+>({
+  steps: {
+    default: {
+      title: t('title'),
+    },
+    form: {
+      previous: 'default',
+    },
+    submission: {},
+  },
+})
+
+// page
+useHeadDefault({ title })
 </script>
 
 <i18n lang="yaml">


### PR DESCRIPTION
### 📚 Description

Instead of using a numbered index, a named stepper composable is extracted.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
