### PR TITLE
fix(server): remove username from password reset emails

### DIFF
--- a/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
+++ b/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
@@ -13,21 +13,19 @@ const {
   locale,
   logoSource,
   passwordResetVerificationLink,
-  username,
   validUntil,
 } = defineProps<{
   emailAddress: string
   locale: Locale
   logoSource?: string
   passwordResetVerificationLink: string
-  username: string
   validUntil: string
 }>()
 
 const locales = {
   de: {
     button: 'Passwort zurücksetzen',
-    header: (username: string) => `Hey, ${username}!`,
+    header: () => `Willkommen zurück!`,
     paragraph1: (siteName: string) =>
       `Es wurde eine Anfrage zum Zurücksetzen des Kennworts für dein ${siteName}-Konto gestellt.`,
     paragraph2:
@@ -41,7 +39,7 @@ const locales = {
   },
   en: {
     button: 'Reset password',
-    header: (username: string) => `Hey, ${username}!`,
+    header: () => `Welcome back!`,
     paragraph1: (siteName: string) =>
       `A request to reset the password for your ${siteName} account has been initiated.`,
     paragraph2:
@@ -70,7 +68,7 @@ const t = locales[locale]
               text-align: center;
             "
           >
-            {{ t.header(username) }}
+            {{ t.header() }}
           </AppText>
         </Column>
       </Row>

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -172,7 +172,6 @@ export const processNotification = async ({
           }/account/password/reset?code=${
             payload.account.password_reset_verification
           }`,
-          username: payload.account.username,
           validUntil: momentFormatDate({
             input: payload.account.password_reset_verification_valid_until,
             format: MOMENT_FORMAT,


### PR DESCRIPTION
### 📚 Description

Password reset emails don't mention the username anymore which increases security.

cc @huzaifaedhi22 I took over this task as I was working on updating the email dependencies already.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
