### PR TITLE
fix(server): use proper unsubscribe list header

### DIFF
--- a/src/server/utils/email.ts
+++ b/src/server/utils/email.ts
@@ -92,19 +92,10 @@ export const sendEmail = async <T extends EmailName>({
     subject: mailOptions.subject,
     text,
     html,
-    headers: {
-      // // TODO: add https link (https://github.com/maevsi/vibetype/issues/326)
-      // 'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
-      'List-Unsubscribe': {
-        prepared: true,
-        value: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,
-      },
+    list: {
+      // TODO: add https link (https://github.com/maevsi/vibetype/issues/326)
+      unsubscribe: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,
     },
-    // // TODO: wait for long line fix (https://github.com/nodemailer/nodemailer/issues/1694)
-    // list: {
-    //   // TODO: add https link (https://github.com/maevsi/vibetype/issues/326)
-    //   unsubscribe: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,
-    // },
     attachments: [
       {
         filename: `${LOGO_CID}.png`,


### PR DESCRIPTION
### 📚 Description

The manual `prepared` header is dropped.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
