### PR TITLE
refactor(components): simplify typography

### DIFF
--- a/src/app/components/app/button/AppButton.vue
+++ b/src/app/components/app/button/AppButton.vue
@@ -33,9 +33,10 @@
 </template>
 
 <script setup lang="ts">
-import { cn } from '@/utils/shadcn'
 import type { ButtonHTMLAttributes, HtmlHTMLAttributes } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
+
+import { cn } from '@/utils/shadcn'
 
 const {
   ariaLabel,

--- a/src/app/components/early-bird/EarlyBirdForm.vue
+++ b/src/app/components/early-bird/EarlyBirdForm.vue
@@ -4,10 +4,8 @@
       <TypographyH6 class="text-center">
         {{ t('title') }}
       </TypographyH6>
-      <TypographyBodyMedium v-slot="attributes">
-        <span v-bind="attributes">
-          {{ t('description') }}
-        </span>
+      <TypographyBodyMedium>
+        {{ t('description') }}
       </TypographyBodyMedium>
     </div>
     <FormEarlyBird ref="form" @success="emit('next')" />

--- a/src/app/components/early-bird/EarlyBirdSubmission.vue
+++ b/src/app/components/early-bird/EarlyBirdSubmission.vue
@@ -1,10 +1,8 @@
 <template>
   <LayoutPage>
     <LayoutPageResult type="success">
-      <TypographyBodySmall v-slot="attributes">
-        <span v-bind="attributes">
-          {{ t('description2') }}
-        </span>
+      <TypographyBodySmall>
+        {{ t('description2') }}
       </TypographyBodySmall>
       <template #description>
         {{ t('description1') }}

--- a/src/app/components/early-bird/EarlyBirdWelcome.vue
+++ b/src/app/components/early-bird/EarlyBirdWelcome.vue
@@ -4,10 +4,8 @@
       <TypographyH6>
         {{ t('title1', { username: store.signedInUsername }) }}
       </TypographyH6>
-      <TypographyBodyMedium v-slot="attributes">
-        <span v-bind="attributes">
-          {{ t('description1') }}
-        </span>
+      <TypographyBodyMedium>
+        {{ t('description1') }}
       </TypographyBodyMedium>
     </div>
     <div class="flex flex-col gap-5">
@@ -15,35 +13,29 @@
         <TypographySubtitleMedium>
           {{ t('title2') }}
         </TypographySubtitleMedium>
-        <TypographyBodySmall v-slot="attributes">
-          <span v-bind="attributes">
-            {{ t('description2') }}
-          </span>
+        <TypographyBodySmall>
+          {{ t('description2') }}
         </TypographyBodySmall>
       </div>
       <div class="flex flex-col gap-2">
         <TypographySubtitleMedium>
           {{ t('title3') }}
         </TypographySubtitleMedium>
-        <TypographyBodySmall v-slot="attributes">
-          <i18n-t keypath="description3">
-            <span v-bind="attributes">
-              {{ t('description3') }}
-            </span>
-            <template #br>
-              <br />
-            </template>
-          </i18n-t>
-        </TypographyBodySmall>
+        <i18n-t keypath="description3">
+          <TypographyBodySmall>
+            {{ t('description3') }}
+          </TypographyBodySmall>
+          <template #br>
+            <br />
+          </template>
+        </i18n-t>
       </div>
       <div class="flex flex-col gap-2">
         <TypographySubtitleMedium>
           {{ t('title4') }}
         </TypographySubtitleMedium>
-        <TypographyBodySmall v-slot="attributes">
-          <span v-bind="attributes">
-            {{ t('description4') }}
-          </span>
+        <TypographyBodySmall>
+          {{ t('description4') }}
         </TypographyBodySmall>
       </div>
     </div>

--- a/src/app/components/typography/TypographyBodyMedium.vue
+++ b/src/app/components/typography/TypographyBodyMedium.vue
@@ -1,5 +1,7 @@
 <template>
-  <slot :class="cn('text-base font-medium', classProps)" />
+  <span :class="cn('text-base font-medium', classProps)">
+    <slot />
+  </span>
 </template>
 
 <script setup lang="ts">

--- a/src/app/components/typography/TypographyBodySmall.vue
+++ b/src/app/components/typography/TypographyBodySmall.vue
@@ -1,5 +1,7 @@
 <template>
-  <slot :class="cn('text-sm font-normal', classProps)" />
+  <span :class="cn('text-sm font-normal', classProps)">
+    <slot />
+  </span>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
### 📚 Description

No need to use `v-slot` and `v-bind` in some cases. Gave some flexibility in usage but that hasn't really been used for these components.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
