### PR TITLE
fix(content): allow websocket connections in stack deployment

### DIFF
--- a/src/config/environments/development.ts
+++ b/src/config/environments/development.ts
@@ -2,6 +2,11 @@ import type { DefineNuxtConfig } from 'nuxt/config'
 
 import { SITE_NAME } from '../../shared/utils/constants'
 
+const HTTPS = {
+  key: './.config/certificates/ssl.key',
+  cert: './.config/certificates/ssl.crt',
+}
+
 export const developmentConfig: ReturnType<DefineNuxtConfig> = {
   $development: {
     build: {
@@ -11,10 +16,7 @@ export const developmentConfig: ReturnType<DefineNuxtConfig> = {
       ? {}
       : {
           devServer: {
-            https: {
-              key: './.config/certificates/ssl.key',
-              cert: './.config/certificates/ssl.crt',
-            },
+            https: HTTPS,
           },
         }),
     devtools: {
@@ -34,6 +36,17 @@ export const developmentConfig: ReturnType<DefineNuxtConfig> = {
     },
 
     // modules
+    content: {
+      watch: {
+        ...(process.env.NUXT_PUBLIC_SITE_URL // TODO: make more readable, find better naming ("enable https only in standalone mode, not when running inside the stack")
+          ? {
+              hostname: '0.0.0.0',
+            }
+          : {
+              https: HTTPS,
+            }),
+      },
+    },
     gtag: {
       enabled: false,
     },


### PR DESCRIPTION
### 📚 Description

Nuxt content's websocket should use the same configuration as Vite's hot module reloading to work when run behind a reverse proxy like traefik.

See:
- https://github.com/maevsi/stack/pull/197

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
