### PR TITLE
chore(package): ignore built dependency `@tailwindcss/oxide`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "@parcel/watcher",
       "@sentry-internal/node-cpu-profiler",
       "@sentry/cli",
+      "@tailwindcss/oxide",
       "better-sqlite3",
       "esbuild",
       "protobufjs",


### PR DESCRIPTION
### 📚 Description

A new dependency can have its build script ignored.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
