### PR TITLE
feat(api-errors): visualize for steppers

### DIFF
--- a/src/app/components/early-bird/EarlyBirdForm.vue
+++ b/src/app/components/early-bird/EarlyBirdForm.vue
@@ -8,7 +8,7 @@
         {{ t('description') }}
       </TypographyBodyMedium>
     </div>
-    <FormEarlyBird ref="form" @success="emit('next')" />
+    <FormEarlyBird v-model:error="error" ref="form" @success="emit('next')" />
     <template #bottom>
       <ButtonColored
         :aria-label="t('button')"
@@ -28,6 +28,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const templateForm = useTemplateRef('form')
+const error = defineModel<Error>('error')
 </script>
 
 <i18n lang="yaml">

--- a/src/app/components/form/FormEarlyBird.vue
+++ b/src/app/components/form/FormEarlyBird.vue
@@ -63,9 +63,10 @@ const emit = defineEmits<{
   success: []
 }>()
 
-const fireAlert = useFireAlert()
 const { t } = useI18n()
 const templateForm = useTemplateRef('form')
+const fetchError = ref(null)
+const modelError = defineModel<Error>('error')
 
 // form
 const submit = () => {
@@ -78,21 +79,25 @@ const { handleSubmit } = useForm({
 })
 const onSubmit = handleSubmit(async (values) => {
   try {
+    fetchError.value = null
+
     await $fetch('/api/service/monday/early-bird', {
       method: 'POST',
       body: values,
     })
+
     emit('success')
   } catch (error) {
-    // TODO: implement form error page
-    await fireAlert({
-      error,
-      level: 'error',
-      text: t('error'),
-      title: t('globalError'),
-    })
+    fetchError.value = error
   }
 })
+
+watch(
+  () => fetchError.value,
+  (error) => {
+    modelError.value = error ? new Error() : undefined
+  },
+)
 
 defineExpose({
   submit,
@@ -102,12 +107,10 @@ defineExpose({
 <i18n lang="yaml">
 de:
   agreement: Mit deiner Teilnahme stimmst du zu, dass wir deine Kontaktdaten speichern und dich im Rahmen des Programms kontaktieren dürfen.
-  error: Die Anmeldung für das Early Bird-Programm scheint nicht geklappt zu haben. Bitte versuche es noch einmal oder wende dich an den Support, wenn das Problem weiterhin besteht.
   emailAddress: E-Mail-Adresse
   name: Name
 en:
   agreement: By participating, you agree that we may save your contact details and contact you as part of the program.
-  error: The registration for the Early Bird program does not seem to have worked. Please try again or contact support if the problem persists.
   emailAddress: Email address
   name: Name
 </i18n>

--- a/src/app/components/form/account/password/FormAccountPasswordReset.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordReset.vue
@@ -1,6 +1,5 @@
 <template>
   <AppForm
-    :errors="api.errors"
     :errors-pg-ids="{
       postgres22023: t('postgres22023'),
       postgresP0002: t('postgresP0002'),
@@ -39,6 +38,7 @@ const form = reactive({
   password: ref<string>(),
 })
 const isFormSent = ref(false)
+const modelError = defineModel<Error>('error')
 
 // api data
 const passwordResetMutation = useAccountPasswordResetMutation()
@@ -67,6 +67,21 @@ const v$ = useVuelidate(rules, form)
 defineExpose({
   submit,
 })
+
+watch(
+  () => api.value.errors,
+  (current) => {
+    modelError.value = current?.length
+      ? new Error(
+          // TODO: Use appropriate error codes here
+          getCombinedErrorMessages(current, {
+            // postgres55000: t('postgres55000'),
+            // postgresP0002: t('postgresP0002'),
+          })[0],
+        )
+      : undefined
+  },
+)
 </script>
 
 <i18n lang="yaml">

--- a/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
@@ -1,7 +1,6 @@
 <template>
   <AppForm
     :class="classProps"
-    :errors="api.errors"
     :form="v$"
     :is-form-sent="isFormSent"
     is-button-hidden
@@ -35,6 +34,7 @@ const form = reactive({
   emailAddress: ref<string>(),
 })
 const isFormSent = ref(false)
+const modelError = defineModel<Error>('error')
 
 // api data
 const passwordResetRequestMutation = useAccountPasswordResetRequestMutation()
@@ -63,4 +63,19 @@ const v$ = useVuelidate(rules, form)
 defineExpose({
   submit,
 })
+
+watch(
+  () => api.value.errors,
+  (current) => {
+    modelError.value = current?.length
+      ? new Error(
+          // TODO: Use appropriate error codes here
+          getCombinedErrorMessages(current, {
+            // postgres55000: t('postgres12345'),
+            // postgresP0002: t('postgresP6789'),
+          })[0],
+        )
+      : undefined
+  },
+)
 </script>

--- a/src/app/pages/account/password/reset/index.vue
+++ b/src/app/pages/account/password/reset/index.vue
@@ -50,6 +50,26 @@
         </template>
       </LayoutPage>
     </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <LayoutPage v-bind="attributes">
+        <LayoutPageResult type="error">
+          {{ error }}
+          <template #description>
+            {{ t('tryAgain') }}
+          </template>
+        </LayoutPageResult>
+        <template #bottom>
+          <ButtonColored
+            :aria-label="t('backToReset')"
+            class="w-full max-w-sm"
+            variant="primary-critical"
+            @click="restart"
+          >
+            {{ t('backToReset') }}
+          </ButtonColored>
+        </template>
+      </LayoutPage>
+    </AppStep>
   </section>
 </template>
 
@@ -66,7 +86,23 @@ const localePath = useLocalePath()
 
 // page
 const { t } = useI18n()
-const title = t('title')
+
+// stepper
+const { error, restart, step, title } = useStepperPage<
+  'default' | 'success' | 'error'
+>({
+  steps: {
+    default: {
+      title: t('title'),
+    },
+    success: {
+      title: t('title'),
+    },
+    error: {
+      title: t('errorTitle'),
+    },
+  },
+})
 useHeadDefault({ title })
 
 // validation
@@ -82,24 +118,27 @@ if (
 // template
 const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
-
-// stepper
-const { step } = useStepper<'default' | 'success'>()
 </script>
 
 <i18n lang="yaml">
 de:
+  backToReset: Zurück zur Passwortzurücksetzung
+  errorTitle: Fehler
   instructionsNew: Neues Passwort
   instructionsSuccessHeading: Passwort erfolgreich zurückgesetzt
   instructionsSuccessDescription: Du kannst dich jetzt mit deinem neuen Passwort anmelden
   reset: Passwort zurücksetzen
   signIn: Einloggen
   title: Passwort zurücksetzen
+  tryAgain: Bitte versuche es erneut
 en:
+  backToReset: Back to Reset Password
+  errorTitle: Error
   instructionsNew: Set a new password
   instructionsSuccessHeading: Password reset successful
   instructionsSuccessDescription: You can now log in using your new password.
   reset: Reset password
   signIn: Log in
   title: Reset password
+  tryAgain: Please try again
 </i18n>

--- a/src/app/pages/account/password/reset/request.vue
+++ b/src/app/pages/account/password/reset/request.vue
@@ -84,9 +84,14 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const { error, restart, step, title } = useStepperPage<'default'>({
+const { error, restart, step, title } = useStepperPage<
+  'default' | 'success' | 'error'
+>({
   steps: {
     default: {
+      title: t('title'),
+    },
+    success: {
       title: t('title'),
     },
     error: {

--- a/src/app/pages/account/password/reset/request.vue
+++ b/src/app/pages/account/password/reset/request.vue
@@ -19,6 +19,7 @@
         <div class="flex justify-center">
           <FormAccountPasswordResetRequest
             ref="form"
+            v-model:error="error"
             class="w-full max-w-md"
             @success="step = 'success'"
           />
@@ -46,42 +47,76 @@
         </LayoutPageResult>
       </LayoutPage>
     </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <LayoutPage v-bind="attributes">
+        <LayoutPageResult type="error">
+          {{ error }}
+          <template #description>
+            {{ t('tryAgain') }}
+          </template>
+        </LayoutPageResult>
+        <template #bottom>
+          <ButtonColored
+            :aria-label="t('backToReset')"
+            class="w-full max-w-sm"
+            variant="primary-critical"
+            @click="restart"
+          >
+            {{ t('backToReset') }}
+          </ButtonColored>
+        </template>
+      </LayoutPage>
+    </AppStep>
   </section>
 </template>
 
 <script setup lang="ts">
+// page
 definePageMeta({
   layout: 'default-no-header',
 })
 
-const localePath = useLocalePath()
-
-// page
 const { t } = useI18n()
-const title = t('title')
-useHeadDefault({ title })
+const localePath = useLocalePath()
 
 // template
 const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const { step } = useStepper<'default' | 'success'>()
+const { error, restart, step, title } = useStepperPage<'default'>({
+  steps: {
+    default: {
+      title: t('title'),
+    },
+    error: {
+      title: t('errorTitle'),
+    },
+  },
+})
+
+useHeadDefault({ title })
 </script>
 
 <i18n lang="yaml">
 de:
+  backToReset: Zurück zur Passwortzurücksetzung
+  errorTitle: Fehler
   iconAltClose: X-Icon
   instructionsInboxDescription: Überprüfe dein Postfach
   instructionsInboxHeading: Befolge die Anweisungen in der E-Mail, um das Passwort zurückzusetzen.
   instructionsRequest: Gib deine E-Mail-Adresse ein, um dein Passwort zurückzusetzen.
   send: Link zum Zurücksetzen senden
   title: Passwort zurücksetzen
+  tryAgain: Bitte versuche es erneut
 en:
+  backToReset: Back to Reset Password
+  errorTitle: Error
   iconAltClose: X icon
   instructionsInboxDescription: Follow the instructions in the email to reset your password.
   instructionsInboxHeading: Check your inbox
   instructionsRequest: Enter your email address to reset your password.
   send: Send reset link
   title: Reset password
+  tryAgain: Please try again
 </i18n>

--- a/src/app/pages/early-bird/create.vue
+++ b/src/app/pages/early-bird/create.vue
@@ -19,10 +19,33 @@
       <EarlyBirdWelcome v-bind="attributes" @next="step = 'form'" />
     </AppStep>
     <AppStep v-slot="attributes" :is-active="step === 'form'">
-      <EarlyBirdForm v-bind="attributes" @next="step = 'submission'" />
+      <EarlyBirdForm
+        v-model:error="error"
+        v-bind="attributes"
+        @next="step = 'submission'"
+      />
     </AppStep>
     <AppStep v-slot="attributes" :is-active="step === 'submission'">
       <EarlyBirdSubmission v-bind="attributes" />
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <LayoutPage v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template #description>
+            {{ t('errorDescription') }}
+          </template>
+        </LayoutPageResult>
+        <template #bottom>
+          <ButtonColored
+            :aria-label="t('backToEarlyBird')"
+            class="w-full max-w-sm"
+            variant="primary-critical"
+            @click="restart"
+          >
+            {{ t('backToEarlyBird') }}
+          </ButtonColored>
+        </template>
+      </LayoutPage>
     </AppStep>
   </section>
 </template>
@@ -51,12 +74,15 @@ if (!store.signedInUsername) {
 }
 
 // stepper
-const { step, previous, title } = useStepperPage<
-  'default' | 'form' | 'submission'
+const { error, step, previous, restart, title } = useStepperPage<
+  'default' | 'form' | 'submission' | 'error'
 >({
   steps: {
     default: {
       title: t('title'),
+    },
+    error: {
+      title: t('errorTitle'),
     },
     form: {
       previous: 'default',
@@ -72,10 +98,16 @@ useHeadDefault({ title })
 <i18n lang="yaml">
 de:
   back: zurück
+  backToEarlyBird: Zurück zur Registrierung
+  errorTitle: Fehler
   iconAltClose: Schließen
   title: Früher Vogel Programm
+  errorDescription: Die Anmeldung für das Early Bird-Programm scheint nicht geklappt zu haben. Bitte versuche es noch einmal oder wende dich an den Support, wenn das Problem weiterhin besteht.
 en:
   back: back
+  backToEarlyBird: Back to Registration
+  errorTitle: Error
   iconAltClose: Close
   title: Early Bird Program
+  errorDescription: The registration for the Early Bird program does not seem to have worked. Please try again or contact support if the problem persists.
 </i18n>


### PR DESCRIPTION
### 📚 Description

This PR visualizes api errors for

- early bird
- password reset request
- password reset
- event report

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
