### PR TITLE
ci: let eslint error only

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,9 @@ importers:
       eslint:
         specifier: 9.26.0
         version: 9.26.0(jiti@2.4.2)
+      eslint-plugin-only-error:
+        specifier: 1.0.2
+        version: 1.0.2
       firebase:
         specifier: 11.7.3
         version: 11.7.3
@@ -6848,6 +6851,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-plugin-only-error@1.0.2:
+    resolution: {integrity: sha512-tdz/EU/LeQLPNMBIQOSl39by+/NGKdhjfba6qDvMWjcbY0GmiMk0bXrIXRGAwW9fksH30Y+KKlK1Jc32bbql9w==}
+    engines: {node: '>=6'}
 
   eslint-plugin-prettier@5.4.0:
     resolution: {integrity: sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==}
@@ -21165,6 +21172,8 @@ snapshots:
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-only-error@1.0.2: {}
 
   eslint-plugin-prettier@5.4.0(@types/eslint@9.6.1)(eslint-config-prettier@10.1.5(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))(prettier@3.5.3):
     dependencies:

--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -5,6 +5,7 @@ import { VIO_ESLINT_CONFIG } from '@dargmuesli/nuxt-vio/.config/lint.js'
 import { createJiti } from 'jiti'
 
 import withNuxt from './.nuxt/eslint.config.mjs'
+import 'eslint-plugin-only-error'
 
 const jiti = createJiti(import.meta.url)
 

--- a/src/package.json
+++ b/src/package.json
@@ -85,6 +85,7 @@
     "downloadjs": "1.4.7",
     "embla-carousel-vue": "8.6.0",
     "eslint": "9.26.0",
+    "eslint-plugin-only-error": "1.0.2",
     "firebase": "11.7.3",
     "firebase-admin": "13.4.0",
     "graphql": "16.11.0",


### PR DESCRIPTION
### 📚 Description

If we don't care about an error/warning we should disable it instead of having warning fly around the codebase. Also by adding this we notice once additional linter rules are turned on as what was fixed in https://github.com/maevsi/vibetype/pull/1936.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
