### PR TITLE
chore(gql): generate type imports for all files

### DIFF
--- a/src/.codegenrc.ts
+++ b/src/.codegenrc.ts
@@ -2,15 +2,14 @@ import type { CodegenConfig } from '@graphql-codegen/cli'
 
 export default {
   schema: 'https://postgraphile.localhost/graphql',
-  documents: ['gql/documents/**/*.ts'],
+  documents: ['gql/documents/**/*.ts'], // ignoreNoDocuments: true,
   hooks: { afterAllFileWrite: ['prettier --write', 'eslint --fix'] },
-  // ignoreNoDocuments: true,
+  config: {
+    useTypeImports: true,
+  },
   generates: {
     './gql/generated/': {
       preset: 'client',
-      config: {
-        useTypeImports: true,
-      },
     },
     'gql/generated/graphcache.ts': {
       plugins: [


### PR DESCRIPTION
### 📚 Description

Saves us from having to revert the `type` removal in generated GraphQL files, the `useTypeImports` configuration is now available for all codegen plugins.

cc @huzaifaedhi22 @myyxl 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
