### PR TITLE
refactor(composables): let stepper include `default` by default

### DIFF
--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -113,9 +113,7 @@ const isOpen = defineModel<boolean>()
 const open = () => (isOpen.value = true)
 
 // stepper
-const { step } = useStepper<
-  'default' | 'reportConfirmation' | 'blockConfirmation'
->()
+const { step } = useStepper<'reportConfirmation' | 'blockConfirmation'>()
 const onAnimationEnd = (isOpen: boolean) => {
   if (isOpen) return
   step.value = 'default'

--- a/src/app/composables/stepper.ts
+++ b/src/app/composables/stepper.ts
@@ -1,9 +1,14 @@
-export const useStepper = <T extends string>(options?: { initial?: T }) => {
-  const { initial = 'default' as T } = options || {}
-  const _step = ref<T>(initial)
+type StepKey<T extends string> = T | 'default'
+type StepValue<T extends string> = T | 'default' | 'error'
+
+export const useStepper = <T extends string>(options?: {
+  initial?: StepKey<T>
+}) => {
+  const { initial = 'default' } = options || {}
+  const _step = ref<StepKey<T>>(initial)
 
   const error = ref<Error>()
-  const step = computed<'error' | T>({
+  const step = computed<StepValue<T>>({
     get: () => (error.value ? 'error' : _step.value),
     set: (value) => (_step.value = value),
   })
@@ -20,10 +25,10 @@ export const useStepper = <T extends string>(options?: { initial?: T }) => {
 }
 
 export const useStepperPage = <T extends string>({
-  initial = 'default' as T,
+  initial = 'default',
   steps,
 }: {
-  initial?: T
+  initial?: StepKey<T>
   steps: {
     default: {
       title?: string
@@ -34,11 +39,11 @@ export const useStepperPage = <T extends string>({
   } & {
     [K in T]: {
       title?: string
-      previous?: T
+      previous?: StepKey<T>
     }
   }
 }) => {
-  const { error, step, restart } = useStepper({
+  const { error, step, restart } = useStepper<T>({
     initial,
   })
   const { t } = useI18n()
@@ -46,9 +51,11 @@ export const useStepperPage = <T extends string>({
   const title = computed(
     () =>
       steps[step.value]?.title ??
-      (step.value === 'error' ? t('globalError') : steps[initial].title),
+      (step.value === 'error' ? t('globalError') : steps['default'].title),
   )
-  const previous = computed(() => steps[step.value].previous)
+  const previous = computed(
+    () => step.value !== 'error' && steps[step.value]?.previous,
+  )
 
   return {
     error,

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -95,7 +95,7 @@ const templateForm = useTemplateRef('form')
 
 // stepper
 const { error, previous, restart, step, title } = useStepperPage<
-  'default' | 'terms' | 'privacy' | 'success'
+  'terms' | 'privacy' | 'success'
 >({
   steps: {
     default: {

--- a/src/app/pages/account/password/reset/index.vue
+++ b/src/app/pages/account/password/reset/index.vue
@@ -84,7 +84,7 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const { step } = useStepper<'default' | 'success'>()
+const { step } = useStepper<'success'>()
 </script>
 
 <i18n lang="yaml">

--- a/src/app/pages/account/password/reset/request.vue
+++ b/src/app/pages/account/password/reset/request.vue
@@ -66,7 +66,7 @@ const templateIdTitle = useId()
 const templateForm = useTemplateRef('form')
 
 // stepper
-const { step } = useStepper<'default' | 'success'>()
+const { step } = useStepper<'success'>()
 </script>
 
 <i18n lang="yaml">

--- a/src/app/pages/early-bird/create.vue
+++ b/src/app/pages/early-bird/create.vue
@@ -51,9 +51,7 @@ if (!store.signedInUsername) {
 }
 
 // stepper
-const { step, previous, title } = useStepperPage<
-  'default' | 'form' | 'submission'
->({
+const { step, previous, title } = useStepperPage<'form' | 'submission'>({
   steps: {
     default: {
       title: t('title'),

--- a/src/app/pages/support/contact/index.vue
+++ b/src/app/pages/support/contact/index.vue
@@ -84,7 +84,7 @@ const title = t('title')
 useHeadDefault({ title })
 
 // stepper
-const { error, step } = useStepper<'default' | 'success'>()
+const { error, step } = useStepper<'success'>()
 </script>
 
 <i18n lang="yaml">


### PR DESCRIPTION
### 📚 Description

Improve stepper typing. It's not necessary to specify `default` anymore, it's included be default.

cc @huzaifaedhi22 

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
