### PR TITLE
fix(types): add workaround for upstream nitro issue

### DIFF
--- a/src/shared/types/api.d.ts
+++ b/src/shared/types/api.d.ts
@@ -5,3 +5,5 @@ import type { GraphQLError } from 'graphql'
 export type BackendError = {
   graphQLErrors: (GraphQLError & { errcode?: string })[]
 } & CombinedError
+
+export default {} // workaround until fix in nitro is released (https://github.com/nitrojs/nitro/pull/3368)

--- a/src/shared/types/utility.d.ts
+++ b/src/shared/types/utility.d.ts
@@ -9,3 +9,5 @@ export type UnionToIntersection<T> = (
 ) extends (x: infer R) => unknown
   ? R
   : never
+
+export default {} // workaround until fix in nitro is released (https://github.com/nitrojs/nitro/pull/3368)


### PR DESCRIPTION
### 📚 Description

Improves typing while we wait for https://github.com/nitrojs/nitro/pull/3368 to be released.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
