### PR TITLE
chore(nuxt): properly place shadcn module configuration

### DIFF
--- a/src/.config/nuxt.ts
+++ b/src/.config/nuxt.ts
@@ -94,10 +94,6 @@ export default defineNuxtConfig({
     },
     'nuxt-security',
   ],
-  shadcn: {
-    prefix: '',
-    componentDir: 'app/components/scn',
-  },
   nitro: {
     compressPublicAssets: true,
     experimental: {

--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -64,6 +64,10 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
       },
     },
   },
+  shadcn: {
+    prefix: '',
+    componentDir: 'app/components/scn',
+  },
   site: {
     url: SITE_URL,
   },


### PR DESCRIPTION
### 📚 Description

Module configuration lives in a separate folder.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
