### PR TITLE
fix(qr-code): force rear camera for iOS PWA compatibility

### DIFF
--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -42,6 +42,7 @@
       </div>
       <Modal id="ModalAttendanceScanQrCode" :submit-name="t('close')">
         <QrCodeStream
+          :constraints="cameraConstraints"
           @detect="onDetect"
           @error="onError"
           @camera-on="onCameraOn"
@@ -148,6 +149,17 @@ const title = computed(() => {
   return `${t('title')} · ${event.value.name}`
 })
 useHeadDefault({ title })
+
+//force rear camera
+const cameraConstraints = computed(() => {
+  const isIOSPWA =
+    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+    window.matchMedia('(display-mode: standalone)').matches
+
+  return {
+    facingMode: isIOSPWA ? { exact: 'environment' } : 'environment',
+  }
+})
 
 // qr code
 const qrCodeScan = () => {


### PR DESCRIPTION
### 📚 Description

Upon opening the camera, it used to show this known error: gruhn/vue-qrcode-reader#298

Fixed by forcing rear camera constraints for iOS PWA, which resolves the camera stream initialization issue.
### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
