### PR TITLE
perf(composables): rework api data getter

### DIFF
--- a/src/app/components/account/AccountProfilePicture.vue
+++ b/src/app/components/account/AccountProfilePicture.vue
@@ -40,21 +40,19 @@ const { t } = useI18n()
 const TUSD_FILES_URL = useTusdFilesUrl()
 
 // api data
-const accountByIdQuery = await useAccountByIdQuery({
+const accountByIdQuery = useAccountByIdQuery({
   id: accountId,
 })
-const profilePictureQuery = await useProfilePictureByAccountIdQuery({
+const profilePictureQuery = useProfilePictureByAccountIdQuery({
   accountId: accountId,
 })
-const api = getApiData([accountByIdQuery, profilePictureQuery])
-const account = computed(() =>
-  getAccountItem(accountByIdQuery.data.value?.accountById),
-)
+const api = await useApiData([accountByIdQuery, profilePictureQuery])
+const account = computed(() => getAccountItem(api.value.data.accountById))
 
 // computations
 const profilePictureUrl = computed(() => {
   const profilePicture = getProfilePictureItem(
-    profilePictureQuery.data.value?.profilePictureByAccountId,
+    api.value.data.profilePictureByAccountId,
   )
   const upload = getUploadItem(profilePicture?.uploadByUploadId)
 

--- a/src/app/components/app/AppDrawer.vue
+++ b/src/app/components/app/AppDrawer.vue
@@ -21,8 +21,4 @@
 
 <script setup lang="ts">
 const isOpen = defineModel<boolean>()
-
-defineExpose({
-  open: () => (isOpen.value = true),
-})
 </script>

--- a/src/app/components/app/AppMap.vue
+++ b/src/app/components/app/AppMap.vue
@@ -4,18 +4,20 @@
 
 <script setup lang="ts">
 import type { Map, LatLng } from 'leaflet'
+import type { DeepReadonly } from 'vue'
 
 import markerIcon from '~/assets/icons/location-on.svg?raw'
 
-export type AppMapProps = {
-  events?: {
-    addressByAddressId?: {
-      location?: {
-        latitude: number
-        longitude: number
-      } | null
+export type AppMapEvent = {
+  addressByAddressId?: {
+    location?: {
+      latitude: number
+      longitude: number
     } | null
-  }[]
+  } | null
+}
+export type AppMapProps = {
+  events?: readonly DeepReadonly<AppMapEvent>[]
   geocoder?: boolean
   positionInitial?: {
     latitude: number

--- a/src/app/components/contact/ContactList.vue
+++ b/src/app/components/contact/ContactList.vue
@@ -95,16 +95,16 @@ const selectedContact = ref<
 >()
 
 // api data
-const contactsQuery = await useAllContactsQuery({
+const contactsQuery = useAllContactsQuery({
   after,
   createdBy: store.signedInAccountId,
   first: ITEMS_PER_PAGE_LARGE,
 })
 const deleteContactByIdMutation = useDeleteContactByIdMutation()
-const api = getApiData([contactsQuery, deleteContactByIdMutation])
+const api = await useApiData([contactsQuery, deleteContactByIdMutation])
 const contacts = computed(
   () =>
-    contactsQuery.data.value?.allContacts?.nodes
+    api.value.data.allContacts?.nodes
       .map((x) => getContactItem(x))
       .filter(isNeitherNullNorUndefined) || [],
 )

--- a/src/app/components/content/legal/ContentLegalTerms.vue
+++ b/src/app/components/content/legal/ContentLegalTerms.vue
@@ -18,14 +18,14 @@ const emit = defineEmits<{
 }>()
 
 // legal terms
-const legalTermsQuery = await zalgo(
-  useAllLegalTermsQuery({
-    language: locale.value,
-  }),
-)
+const legalTermsQuery = useAllLegalTermsQuery({
+  language: locale.value,
+})
+const api = await useApiData([legalTermsQuery])
+
 const legalTermFirst = computed(
   () =>
-    legalTermsQuery.data.value?.allLegalTerms?.nodes
+    api.value.data.allLegalTerms?.nodes
       ?.map(getLegalTermItem)
       .filter(isNeitherNullNorUndefined)[0],
 )

--- a/src/app/components/event/EventList.vue
+++ b/src/app/components/event/EventList.vue
@@ -18,12 +18,14 @@
 </template>
 
 <script setup lang="ts">
-import type { AppMapProps } from '~/components/app/AppMap.vue'
+import type { DeepReadonly } from 'vue'
+
+import type { AppMapEvent } from '~/components/app/AppMap.vue'
 import type { EventCardProps } from './card/EventCard.vue'
 
 // compiler
 const { events = undefined, hasNextPage } = defineProps<{
-  events?: EventCardProps['event'][] & AppMapProps['events']
+  events?: DeepReadonly<(EventCardProps['event'] & AppMapEvent)[]>
   hasNextPage?: boolean
 }>()
 

--- a/src/app/components/event/EventSearch.vue
+++ b/src/app/components/event/EventSearch.vue
@@ -119,15 +119,13 @@ const queryEventSearch = graphql(`
 `)
 
 const allEventsQueryAfter = ref<string>()
-const allEventsQuery = await zalgo(
-  useQuery({
-    query: queryEventList,
-    variables: {
-      after: allEventsQueryAfter,
-      first: ITEMS_PER_PAGE,
-    } satisfies MaybeRefObj<EventListQueryVariables>,
-  }),
-)
+const allEventsQuery = useQuery({
+  query: queryEventList,
+  variables: {
+    after: allEventsQueryAfter,
+    first: ITEMS_PER_PAGE,
+  } satisfies MaybeRefObj<EventListQueryVariables>,
+})
 
 const searchQuery = ref<string>()
 const searchQueryDebounced = refDebounced(searchQuery, 300)
@@ -135,16 +133,14 @@ const searchQueryVariable = computed(() =>
   searchQueryDebounced.value?.trim().split(/\s+/).join(' OR '),
 )
 const searchResultsQueryAfter = ref<string>()
-const searchResultsQuery = await zalgo(
-  useQuery({
-    query: queryEventSearch,
-    variables: {
-      after: searchResultsQueryAfter,
-      query: searchQueryVariable,
-      first: ITEMS_PER_PAGE,
-    } satisfies MaybeRefObj<EventSearchQueryVariables>,
-  }),
-)
+const searchResultsQuery = useQuery({
+  query: queryEventSearch,
+  variables: {
+    after: searchResultsQueryAfter,
+    query: searchQueryVariable,
+    first: ITEMS_PER_PAGE,
+  } satisfies MaybeRefObj<EventSearchQueryVariables>,
+})
 watch(searchQueryVariable, () => {
   searchResultsQueryAfter.value = undefined
 })
@@ -154,8 +150,8 @@ const query = computed(() =>
 )
 const pageInfo = computed(() =>
   searchQueryVariable.value
-    ? searchResultsQuery.data.value?.eventSearch?.pageInfo
-    : allEventsQuery.data.value?.allEvents?.pageInfo,
+    ? api.value.data.eventSearch?.pageInfo
+    : api.value.data.allEvents?.pageInfo,
 )
 const events = computed(() => {
   if (!query.value.data.value) return
@@ -171,7 +167,7 @@ const events = computed(() => {
   return undefined
 })
 
-const api = getApiData([query.value])
+const api = await useApiData([query.value])
 const loadMore = () => {
   if (!query.value.data.value) return
 

--- a/src/app/components/event/card/EventCard.vue
+++ b/src/app/components/event/card/EventCard.vue
@@ -93,14 +93,15 @@
 
 <script setup lang="ts">
 import type { OperationResult } from '@urql/core'
+import { useMutation } from '@urql/vue'
+import type { DeepReadonly } from 'vue'
 
 import { cn } from '@/utils/shadcn'
-import { useMutation } from '@urql/vue'
 import { graphql } from '~~/gql/generated'
 
 // compiler
 export type EventCardProps = {
-  event: {
+  event: DeepReadonly<{
     id: string
     accountByCreatedBy?: {
       id?: string
@@ -124,7 +125,7 @@ export type EventCardProps = {
     name: string
     slug: string
     start: string
-  }
+  }>
 }
 const { event } = defineProps<EventCardProps>()
 
@@ -180,7 +181,7 @@ const deleteEventFavoriteByIdMutation = useMutation(
     }
   `),
 )
-const api = getApiData([
+const api = await useApiData([
   createEventFavoriteMutation,
   deleteEventFavoriteByIdMutation,
 ])

--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -109,8 +109,7 @@ const { accountId, event } = defineProps<{
 const templateForm = useTemplateRef('form')
 
 // drawer
-const isOpen = defineModel<boolean>()
-const open = () => (isOpen.value = true)
+const isOpen = defineModel<boolean>('open')
 
 // stepper
 const { step } = useStepper<'reportConfirmation' | 'blockConfirmation'>()
@@ -121,7 +120,7 @@ const onAnimationEnd = (isOpen: boolean) => {
 
 // block
 const createAccountBlockMutation = useCreateAccountBlockMutation()
-const api = getApiData([createAccountBlockMutation])
+const api = await useApiData([createAccountBlockMutation])
 const apiErrorMessages = computed(() =>
   getCombinedErrorMessages(api.value.errors),
 )
@@ -161,10 +160,6 @@ const backToDashboard = async () =>
       name: 'dashboard',
     }),
   )
-
-defineExpose({
-  open,
-})
 </script>
 
 <i18n lang="yaml">

--- a/src/app/components/event/report/EventReportForm.vue
+++ b/src/app/components/event/report/EventReportForm.vue
@@ -47,18 +47,15 @@ const reasons = [
 ]
 const templateForm = useTemplateRef('form')
 
-// report
-const createReportMutation = useCreateReportMutation()
-const api = getApiData([createReportMutation])
-const apiErrorMessages = computed(() =>
-  getCombinedErrorMessages(api.value.errors),
-)
-
 // form
 const submit = () =>
   templateForm.value?.dispatchEvent(
     new Event('submit', { bubbles: true, cancelable: true }),
   )
+// TODO: try to dissolve `defineExpose`
+defineExpose({
+  submit,
+})
 const { handleSubmit } = useForm({
   validationSchema: toTypedSchema(
     z.object({
@@ -98,9 +95,12 @@ const onSubmit = handleSubmit(async (values) => {
   emit('submitSuccess')
 })
 
-defineExpose({
-  submit,
-})
+// api data
+const createReportMutation = useCreateReportMutation()
+const api = await useApiData([createReportMutation])
+const apiErrorMessages = computed(() =>
+  getCombinedErrorMessages(api.value.errors),
+)
 </script>
 
 <i18n lang="yaml">

--- a/src/app/components/form/FormContact.vue
+++ b/src/app/components/form/FormContact.vue
@@ -166,7 +166,7 @@ const isFormSent = ref(false)
 // api data
 const createContactMutation = useCreateContactMutation()
 const updateContactByIdMutation = useUpdateContactByIdMutation()
-const api = getApiData([createContactMutation, updateContactByIdMutation])
+const api = await useApiData([createContactMutation, updateContactByIdMutation])
 
 // methods
 const submit = async () => {

--- a/src/app/components/form/FormDelete.vue
+++ b/src/app/components/form/FormDelete.vue
@@ -49,7 +49,7 @@ const form = reactive({
 const isFormSent = ref(false)
 
 // api data
-const api = getApiData([mutation])
+const api = await useApiData([mutation])
 
 // methods
 const submit = async () => {

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -318,7 +318,7 @@ const isFormSent = ref(false)
 // api data
 const createEventMutation = useCreateEventMutation()
 const updateEventMutation = useUpdateEventByIdMutation()
-const api = getApiData([createEventMutation, updateEventMutation])
+const api = await useApiData([createEventMutation, updateEventMutation])
 
 // methods
 const dateTimeFormatter = (x?: string) =>

--- a/src/app/components/form/FormGuest.vue
+++ b/src/app/components/form/FormGuest.vue
@@ -115,16 +115,16 @@ const form = reactive({
 const isFormSent = ref(false)
 
 // api data
-const allContactsQuery = await useAllContactsQuery({
+const allContactsQuery = useAllContactsQuery({
   after,
   createdBy: store.signedInAccountId,
   first: ITEMS_PER_PAGE_LARGE,
 })
 const createGuestMutation = useCreateGuestMutation()
-const api = getApiData([allContactsQuery, createGuestMutation])
+const api = await useApiData([allContactsQuery, createGuestMutation])
 const contacts = computed(
   () =>
-    allContactsQuery.data.value?.allContacts?.nodes
+    api.value.data.allContacts?.nodes
       .map((x) => getContactItem(x))
       .filter(isNeitherNullNorUndefined) || [],
 )

--- a/src/app/components/form/account/FormAccountSignIn.vue
+++ b/src/app/components/form/account/FormAccountSignIn.vue
@@ -65,7 +65,7 @@ const modelError = defineModel<Error>('error')
 
 // api data
 const authenticateMutation = useAuthenticateMutation()
-const api = getApiData([authenticateMutation])
+const api = await useApiData([authenticateMutation])
 
 // methods
 const submit = async () => {

--- a/src/app/components/form/account/password/FormAccountPasswordChange.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordChange.vue
@@ -43,7 +43,7 @@ const isFormSent = ref(false)
 
 // api data
 const accountPasswordChangeMutation = useAccountPasswordChangeMutation()
-const api = getApiData([accountPasswordChangeMutation])
+const api = await useApiData([accountPasswordChangeMutation])
 
 // methods
 const resetForm = () => {

--- a/src/app/components/form/account/password/FormAccountPasswordReset.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordReset.vue
@@ -32,19 +32,11 @@ const emit = defineEmits<{
   success: []
 }>()
 
-const { t } = useI18n()
-
-// data
+// form
 const form = reactive({
   password: ref<string>(),
 })
 const isFormSent = ref(false)
-
-// api data
-const passwordResetMutation = useAccountPasswordResetMutation()
-const api = getApiData([passwordResetMutation])
-
-// methods
 const submit = async () => {
   if (!(await isFormValid({ v$, isFormSent }))) return
 
@@ -57,6 +49,14 @@ const submit = async () => {
 
   emit('success')
 }
+// TODO: try to dissolve `defineExpose`
+defineExpose({
+  submit,
+})
+
+// api data
+const passwordResetMutation = useAccountPasswordResetMutation()
+const api = await useApiData([passwordResetMutation])
 
 // vuelidate
 const rules = {
@@ -64,9 +64,8 @@ const rules = {
 }
 const v$ = useVuelidate(rules, form)
 
-defineExpose({
-  submit,
-})
+// template
+const { t } = useI18n()
 </script>
 
 <i18n lang="yaml">

--- a/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
@@ -36,10 +36,6 @@ const form = reactive({
 })
 const isFormSent = ref(false)
 
-// api data
-const passwordResetRequestMutation = useAccountPasswordResetRequestMutation()
-const api = getApiData([passwordResetRequestMutation])
-
 // methods
 const submit = async () => {
   if (!(await isFormValid({ v$, isFormSent }))) return
@@ -53,14 +49,18 @@ const submit = async () => {
 
   emit('success')
 }
+// TODO: try to dissolve `defineExpose`
+defineExpose({
+  submit,
+})
+
+// api data
+const passwordResetRequestMutation = useAccountPasswordResetRequestMutation()
+const api = await useApiData([passwordResetRequestMutation])
 
 // vuelidate
 const rules = {
   emailAddress: VALIDATION_EMAIL_ADDRESS({ isRequired: true }),
 }
 const v$ = useVuelidate(rules, form)
-
-defineExpose({
-  submit,
-})
 </script>

--- a/src/app/components/guest/GuestList.vue
+++ b/src/app/components/guest/GuestList.vue
@@ -132,12 +132,12 @@ const options = {
 }
 
 // api data
-const guestsQuery = await useAllGuestsQuery({
+const guestsQuery = useAllGuestsQuery({
   after,
   eventId: event.id,
   first: ITEMS_PER_PAGE_LARGE,
 })
-const api = getApiData([guestsQuery])
+const api = await useApiData([guestsQuery])
 
 // methods
 const add = () => {
@@ -195,7 +195,7 @@ const dataComputed = computed(() => {
 })
 const guests = computed(
   () =>
-    guestsQuery.data.value?.allGuests?.nodes
+    api.value.data.allGuests?.nodes
       .map((x) => getGuestItem(x))
       .filter(isNeitherNullNorUndefined) || [],
 )

--- a/src/app/components/guest/GuestListItem.vue
+++ b/src/app/components/guest/GuestListItem.vue
@@ -126,7 +126,7 @@ const pending = reactive({
 // api data
 const deleteGuestByIdMutation = useDeleteGuestByIdMutation()
 const inviteMutation = useInviteMutation()
-// const api = getApiData([deleteGuestByIdMutation, inviteMutation])
+// const api = await useApiData([deleteGuestByIdMutation, inviteMutation])
 
 // methods
 const copyLink = async (guest: Pick<GuestItemFragment, 'id'>) => {

--- a/src/app/components/loader/Loader.vue
+++ b/src/app/components/loader/Loader.vue
@@ -23,7 +23,7 @@ const {
   indicator = undefined,
 } = defineProps<
   {
-    api: UnwrapRef<ReturnType<typeof getApiData>>
+    api: UnwrapRef<Awaited<ReturnType<typeof useApiData>>>
     errorPgIds?: Record<string, string>
     indicator?: string
   } & { class?: HtmlHTMLAttributes['class'] }

--- a/src/app/components/preference/form/PreferenceFormSize.vue
+++ b/src/app/components/preference/form/PreferenceFormSize.vue
@@ -56,16 +56,15 @@ const submit = () =>
   templateForm.value?.dispatchEvent(
     new Event('submit', { bubbles: true, cancelable: true }),
   )
+// TODO: try to dissolve `defineExpose`
 defineExpose({ submit })
 
 // api data
-const allPreferenceEventSizesQuery = await zalgo(
-  useAllPreferenceEventSizesQuery(),
-)
+const allPreferenceEventSizesQuery = useAllPreferenceEventSizesQuery()
 const createPreferenceEventSizeMutation = useCreatePreferenceEventSizeMutation()
 const deletePreferenceEventSizeByAccountIdAndEventSizeMutation =
   useDeletePreferenceEventSizeByAccountIdAndEventSizeMutation()
-const api = getApiData([
+const api = await useApiData([
   allPreferenceEventSizesQuery,
   createPreferenceEventSizeMutation,
   deletePreferenceEventSizeByAccountIdAndEventSizeMutation,
@@ -97,7 +96,7 @@ const items = [
 ]
 const modelError = defineModel<Error>('error')
 const initialSelectedItems =
-  allPreferenceEventSizesQuery.data.value?.allPreferenceEventSizes?.nodes?.map(
+  api.value.data.allPreferenceEventSizes?.nodes?.map(
     (preference) => preference.eventSize,
   ) ?? []
 const { handleSubmit } = useForm({

--- a/src/app/components/preference/step/PreferenceStepCategory.vue
+++ b/src/app/components/preference/step/PreferenceStepCategory.vue
@@ -117,15 +117,13 @@ const translate = (nameKey: string) => {
 }
 
 // api data
-const allCategoriesQuery = await zalgo(useAllEventCategoriesQuery())
-const allPreferenceEventCategoriesQuery = await zalgo(
-  useAllPreferenceEventCategoriesQuery(),
-)
+const allCategoriesQuery = useAllEventCategoriesQuery()
+const allPreferenceEventCategoriesQuery = useAllPreferenceEventCategoriesQuery()
 const createPreferenceEventCategoryMutation =
   useCreatePreferenceEventCategoryMutation()
 const deletePreferenceEventCategoryByAccountIdAndCategoryIdMutation =
   useDeletePreferenceEventCategoryByAccountIdAndCategoryIdMutation()
-const api = getApiData([
+const api = await useApiData([
   allCategoriesQuery,
   allPreferenceEventCategoriesQuery,
   createPreferenceEventCategoryMutation,

--- a/src/app/components/preference/step/PreferenceStepFormat.vue
+++ b/src/app/components/preference/step/PreferenceStepFormat.vue
@@ -114,15 +114,13 @@ const translate = (nameKey: string) => {
 }
 
 // api data
-const allFormatsQuery = await zalgo(useAllEventFormatsQuery())
-const allPreferenceEventFormatsQuery = await zalgo(
-  useAllPreferenceEventFormatsQuery(),
-)
+const allFormatsQuery = useAllEventFormatsQuery()
+const allPreferenceEventFormatsQuery = useAllPreferenceEventFormatsQuery()
 const createPreferenceEventFormatMutation =
   useCreatePreferenceEventFormatMutation()
 const deletePreferenceEventFormatByAccountIdAndFormatIdMutation =
   useDeletePreferenceEventFormatByAccountIdAndFormatIdMutation()
-const api = getApiData([
+const api = await useApiData([
   allFormatsQuery,
   allPreferenceEventFormatsQuery,
   createPreferenceEventFormatMutation,

--- a/src/app/components/preference/step/PreferenceStepLocation.vue
+++ b/src/app/components/preference/step/PreferenceStepLocation.vue
@@ -49,14 +49,12 @@ const emit = defineEmits<{
 const { t, locale } = useI18n()
 
 // api data
-const allPreferenceEventLocationsQuery = await zalgo(
-  useAllPreferenceEventLocationsQuery(),
-)
+const allPreferenceEventLocationsQuery = useAllPreferenceEventLocationsQuery()
 const createPreferenceEventLocationMutation =
   useCreatePreferenceEventLocationMutation()
 const deletePreferenceEventLocationByIdMutation =
   useDeletePreferenceEventLocationByIdMutation()
-const api = getApiData([
+const api = await useApiData([
   allPreferenceEventLocationsQuery,
   createPreferenceEventLocationMutation,
   deletePreferenceEventLocationByIdMutation,
@@ -110,7 +108,7 @@ const getZoomLevelForRadius = ({
   )
 const preferenceEventLocations = computed(
   () =>
-    allPreferenceEventLocationsQuery.data.value?.allPreferenceEventLocations?.nodes
+    api.value.data.allPreferenceEventLocations?.nodes
       .map((item) => getPreferenceEventLocationItem(item))
       .filter(isNeitherNullNorUndefined) || [],
 )

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -160,15 +160,15 @@ const selectedItem = ref<{
 const uppy = ref<Uppy<{ id: string }>>()
 
 // api data
-const accountUploadQuotaBytesQuery = await useAccountUploadQuotaBytesQuery({})
-const allUploadsQuery = await useAllUploadsQuery({
+const accountUploadQuotaBytesQuery = useAccountUploadQuotaBytesQuery({})
+const allUploadsQuery = useAllUploadsQuery({
   after,
   first: ITEMS_PER_PAGE,
   createdBy: store.signedInAccountId,
 })
 const deleteUploadByIdMutation = useDeleteUploadByIdMutation()
 const uploadCreateMutation = useCreateUploadMutation()
-const api = getApiData([
+const api = await useApiData([
   accountUploadQuotaBytesQuery,
   allUploadsQuery,
   deleteUploadByIdMutation,
@@ -176,12 +176,12 @@ const api = getApiData([
 ])
 const uploads = computed(
   () =>
-    allUploadsQuery.data.value?.allUploads?.nodes
+    api.value.data.allUploads?.nodes
       .map((x) => getUploadItem(x))
       .filter(isNeitherNullNorUndefined) || [],
 )
 const accountUploadQuotaBytes = computed(
-  () => accountUploadQuotaBytesQuery.data.value?.accountUploadQuotaBytes,
+  () => api.value.data.accountUploadQuotaBytes,
 )
 
 // computations

--- a/src/app/composables/api.ts
+++ b/src/app/composables/api.ts
@@ -1,15 +1,22 @@
+import type {
+  AnyVariables,
+  UseMutationResponse,
+  UseQueryResponse,
+} from '@urql/vue'
 import { consola } from 'consola'
 
-export const getApiData = <
+// TODO: account for errors in page setups
+export const useApiData = async <
+  T extends UseMutationResponse<S, V> | UseQueryResponse<S, V>,
   S,
-  T extends {
-    data: Ref<S>
-    error: Ref<BackendError | undefined>
-    fetching: Ref<boolean>
-  },
+  V extends AnyVariables = AnyVariables,
 >(
-  queries: T[] = [],
+  queriesInput: T[] = [],
 ) => {
+  const queries = import.meta.server
+    ? await Promise.all(queriesInput)
+    : queriesInput
+
   const apiData = computed(() =>
     readonly({
       data: queries.reduce(

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -12,13 +12,7 @@
     </LayoutTopBar>
     <AppStep v-slot="attributes" :is-active="step === 'default'">
       <LayoutPage v-bind="attributes">
-        <FormAccountRegistration
-          ref="form"
-          v-model:error="error"
-          :birth-date
-          @submit="step = 'age'"
-          @success="step = 'success'"
-        />
+        <FormAccountRegistration v-model:form="form" @submit="step = 'age'" />
         <ContentLegalFooter />
       </LayoutPage>
     </AppStep>
@@ -47,7 +41,7 @@
       <AccountLegalConsent
         v-bind="attributes"
         :label="t('agreePrivacy')"
-        @agreement="templateForm?.submit(legalTermId || '')"
+        @agreement="submit(legalTermId || '')"
       >
         <Content path="privacy-consent" />
       </AccountLegalConsent>
@@ -95,16 +89,68 @@
 </template>
 
 <script setup lang="ts">
+import { useAccountRegistrationMutation } from '~~/gql/documents/mutations/account/accountRegistration'
+
 definePageMeta({
   layout: 'plain',
 })
 
-const { t } = useI18n()
+const { locale, t } = useI18n()
+
+// api data
+const accountRegistrationMutation = useAccountRegistrationMutation()
+const api = await useApiData([accountRegistrationMutation])
+// TODO: move into api utility as `errorsTranslated`
+watch(
+  () => api.value.errors,
+  (current) => {
+    error.value = current?.length
+      ? new Error(
+          getCombinedErrorMessages(current, {
+            postgresVTAUV: t('postgresVTAUV'),
+            postgresVTBDA: t('postgresVTBDA'),
+            postgresVTPLL: t('postgresVTPLL'),
+          })[0],
+        )
+      : undefined
+  },
+)
 
 // template
 const templateIdTitle = useId()
-const templateForm = useTemplateRef('form')
 const birthDate = ref<string>()
+
+// form
+const form = reactive({
+  captcha: ref<string>(),
+  emailAddress: ref<string>(),
+  password: ref<string>(),
+  passwordRepetition: ref<string>(),
+  username: ref<string>(),
+})
+const submit = async (termId: string) => {
+  const result = await accountRegistrationMutation.executeMutation(
+    {
+      birthDate: birthDate,
+      emailAddress: form.emailAddress || '',
+      language: locale.value,
+      legalTermId: termId,
+      password: form.password || '',
+      username: form.username || '',
+    },
+    {
+      fetchOptions: {
+        headers: {
+          ...(form.captcha && { [TURNSTILE_HEADER_KEY]: form.captcha }),
+        },
+      },
+    },
+  )
+
+  if (result.error || !result.data) return
+
+  step.value = 'success'
+}
 
 // stepper
 const { error, previous, restart, step, title } = useStepperPage<
@@ -145,6 +191,9 @@ de:
   agreePrivacy: Ich stimme der Datenschutzerklärung zu
   back: zurück
   backToRegistration: Zurück zur Registrierung
+  postgresVTAUV: Es gibt bereits einen Account mit diesem Nutzernamen! Überlege dir einen neuen Namen oder versuche dich anzumelden.
+  postgresVTBDA: Du musst mindestens 18 Jahre alt sein, um dich zu registrieren.
+  postgresVTPLL: Das Passwort ist zu kurz! Überlege dir ein längeres.
   titleAge: Bereit für Social Media?
   titleForm: Erstelle ein Konto
   titlePrivacy: Datenschutzbestimmungen
@@ -158,6 +207,9 @@ en:
   agreePrivacy: I agree to the Privacy Policy
   back: back
   backToRegistration: Back to Registration
+  postgresVTAUV: This username is already in use! Think of a new name or try signing in instead.
+  postgresVTBDA: You must be at least 18 years old to register.
+  postgresVTPLL: Your password is too short! Think of a longer one.
   titleAge: Ready for Social Media?
   titleForm: Create an account
   titlePrivacy: Privacy Policy

--- a/src/app/pages/account/edit/[username].vue
+++ b/src/app/pages/account/edit/[username].vue
@@ -65,16 +65,15 @@ if (route.params.username !== store.signedInUsername) {
 
 // api data
 const accountDeleteMutation = useAccountDeleteMutation()
-const accountByUsernameQuery = await zalgo(
-  useAccountByUsernameQuery({
-    username: route.params.username,
-  }),
-)
-const account = getAccountItem(
-  accountByUsernameQuery.data.value?.accountByUsername,
-)
+const accountByUsernameQuery = useAccountByUsernameQuery({
+  username: route.params.username,
+})
 const profilePictureSetMutation = useProfilePictureSetMutation()
-const api = getApiData([accountByUsernameQuery, profilePictureSetMutation])
+const api = await useApiData([
+  accountByUsernameQuery,
+  profilePictureSetMutation,
+])
+const account = getAccountItem(api.value.data.accountByUsername)
 
 // methods
 const onUploadSelect = async (uploadId?: string | null | undefined) =>

--- a/src/app/pages/account/verify/index.vue
+++ b/src/app/pages/account/verify/index.vue
@@ -41,7 +41,7 @@ const templateIdTitle = useId()
 // api data
 const accountEmailAddressVerificationMutation =
   useAccountEmailAddressVerificationMutation()
-const api = getApiData([accountEmailAddressVerificationMutation])
+const api = await useApiData([accountEmailAddressVerificationMutation])
 
 // lifecycle
 const fireAlert = useFireAlert()

--- a/src/app/pages/account/view/[username].vue
+++ b/src/app/pages/account/view/[username].vue
@@ -225,15 +225,13 @@ useHeadDefault({
 })
 
 // api data
-const query = await zalgo(
-  useQuery({
-    query: queryAccount,
-    variables: {
-      username: route.params.username,
-    } satisfies MaybeRefObj<AccountQueryVariables>,
-  }),
-)
-const api = getApiData([query])
+const query = useQuery({
+  query: queryAccount,
+  variables: {
+    username: route.params.username,
+  } satisfies MaybeRefObj<AccountQueryVariables>,
+})
+const api = await useApiData([query])
 const account = computed(() => query.data.value?.accountByUsername)
 const accountDescription = computed(() => account.value?.description?.trim())
 const achievements = computed(
@@ -247,8 +245,9 @@ const events = computed(() =>
 )
 
 // account
-if (!account.value) {
-  throw createError({
+if (account.value === null) {
+  throw showError({
+    message: 'Account data missing',
     statusCode: 404,
   })
 }

--- a/src/app/pages/event/edit/[username]/[event_name].vue
+++ b/src/app/pages/event/edit/[username]/[event_name].vue
@@ -52,36 +52,31 @@ if (route.params.username !== store.signedInUsername) {
 }
 
 // api data
-const accountByUsernameQuery = await zalgo(
-  useAccountByUsernameQuery({
-    username: route.params.username,
-  }),
-)
-const accountId = computed(
-  () =>
-    getAccountItem(accountByUsernameQuery.data.value?.accountByUsername)?.id,
-)
-if (!accountId.value) {
-  throw createError({
+const accountByUsernameQuery = useAccountByUsernameQuery({
+  username: route.params.username,
+})
+const account = computed(() => getAccountItem(api.value.data.accountByUsername))
+if (account.value === null) {
+  throw showError({
+    message: 'Account data missing',
     statusCode: 404,
   })
 }
-const eventQuery = await zalgo(
-  useEventByCreatedByAndSlugQuery({
-    createdBy: accountId,
-    slug: route.params.event_name,
-  }),
-)
+const eventQuery = useEventByCreatedByAndSlugQuery({
+  createdBy: account.value?.id,
+  slug: route.params.event_name,
+})
 const event = computed(() =>
-  getEventItem(eventQuery.data.value?.eventByCreatedByAndSlug),
+  getEventItem(api.value.data.eventByCreatedByAndSlug),
 )
-if (!event.value) {
-  throw createError({
+if (event.value === null) {
+  throw showError({
+    message: 'Event data missing',
     statusCode: 404,
   })
 }
 const eventDeleteMutation = useEventDeleteMutation()
-const api = getApiData([
+const api = await useApiData([
   accountByUsernameQuery,
   eventQuery,
   eventDeleteMutation,

--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -108,35 +108,30 @@ if (route.params.username !== store.signedInUsername) {
 }
 
 // api data
-const accountByUsernameQuery = await zalgo(
-  useAccountByUsernameQuery({
-    username: route.params.username,
-  }),
-)
-const accountId = computed(
-  () =>
-    getAccountItem(accountByUsernameQuery.data.value?.accountByUsername)?.id,
-)
-if (!accountId.value) {
-  throw createError({
+const accountByUsernameQuery = useAccountByUsernameQuery({
+  username: route.params.username,
+})
+const account = computed(() => getAccountItem(api.value.data.accountByUsername))
+if (account.value === null) {
+  throw showError({
+    message: 'Account data missing',
     statusCode: 404,
   })
 }
-const eventQuery = await zalgo(
-  useEventByCreatedByAndSlugQuery({
-    createdBy: accountId,
-    slug: route.params.event_name,
-  }),
-)
+const eventQuery = useEventByCreatedByAndSlugQuery({
+  createdBy: account.value?.id,
+  slug: route.params.event_name,
+})
 const event = computed(() =>
-  getEventItem(eventQuery.data.value?.eventByCreatedByAndSlug),
+  getEventItem(api.value.data.eventByCreatedByAndSlug),
 )
-if (!event.value) {
-  throw createError({
+if (event.value === null) {
+  throw showError({
+    message: 'Event data missing',
     statusCode: 404,
   })
 }
-const api = getApiData([accountByUsernameQuery, eventQuery])
+const api = await useApiData([accountByUsernameQuery, eventQuery])
 
 // page
 const title = computed(() => {

--- a/src/app/pages/event/view/[username]/[event_name]/guest.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/guest.vue
@@ -29,35 +29,30 @@ if (route.params.username !== store.signedInUsername) {
 }
 
 // api data
-const accountByUsernameQuery = await zalgo(
-  useAccountByUsernameQuery({
-    username: route.params.username,
-  }),
-)
-const accountId = computed(
-  () =>
-    getAccountItem(accountByUsernameQuery.data.value?.accountByUsername)?.id,
-)
-if (!accountId.value) {
-  throw createError({
+const accountByUsernameQuery = useAccountByUsernameQuery({
+  username: route.params.username,
+})
+const account = computed(() => getAccountItem(api.value.data.accountByUsername))
+if (account.value === null) {
+  throw showError({
+    message: 'Account data missing',
     statusCode: 404,
   })
 }
-const eventQuery = await zalgo(
-  useEventByCreatedByAndSlugQuery({
-    createdBy: accountId,
-    slug: route.params.event_name,
-  }),
-)
+const eventQuery = useEventByCreatedByAndSlugQuery({
+  createdBy: account.value?.id,
+  slug: route.params.event_name,
+})
 const event = computed(() =>
-  getEventItem(eventQuery.data.value?.eventByCreatedByAndSlug),
+  getEventItem(api.value.data.eventByCreatedByAndSlug),
 )
-if (!event.value) {
-  throw createError({
+if (event.value === null) {
+  throw showError({
+    message: 'Event data missing',
     statusCode: 404,
   })
 }
-const api = getApiData([accountByUsernameQuery, eventQuery])
+const api = await useApiData([accountByUsernameQuery, eventQuery])
 
 // computations
 const title = computed(() => {

--- a/src/app/pages/event/view/[username]/index.vue
+++ b/src/app/pages/event/view/[username]/index.vue
@@ -82,24 +82,27 @@ useHeadDefault({
 
 // api data
 const queryAfter = ref<string>()
-const query = await zalgo(
-  useQuery({
-    query: queryEventListAccount,
-    variables: {
-      after: queryAfter,
-      first: ITEMS_PER_PAGE,
-      username: route.params.username,
-    } satisfies MaybeRefObj<EventListAccountQueryVariables>,
-  }),
+const query = useQuery({
+  query: queryEventListAccount,
+  variables: {
+    after: queryAfter,
+    first: ITEMS_PER_PAGE,
+    username: route.params.username,
+  } satisfies MaybeRefObj<EventListAccountQueryVariables>,
+})
+const api = await useApiData([query])
+const account = computed(() => api.value.data.accountByUsername)
+const events = computed(() =>
+  account.value?.eventsByCreatedBy.nodes.map((event) => ({
+    ...event,
+    accountByCreatedBy: { ...account.value, username: route.params.username },
+  })),
 )
 
-const api = getApiData([query])
-const account = computed(() => query.data.value?.accountByUsername)
-const events = computed(() => account.value?.eventsByCreatedBy.nodes)
-
 // validation
-if (!account.value) {
-  throw createError({
+if (account.value === null) {
+  throw showError({
+    message: 'Account data missing',
     statusCode: 404,
   })
 }

--- a/src/app/pages/guest/unlock.vue
+++ b/src/app/pages/guest/unlock.vue
@@ -171,7 +171,7 @@ const title = t('title')
 
 // api data
 const eventUnlockMutation = useEventUnlockMutation()
-const api = getApiData([eventUnlockMutation])
+const api = await useApiData([eventUnlockMutation])
 
 // methods
 const submit = async () => {

--- a/src/app/pages/index.vue
+++ b/src/app/pages/index.vue
@@ -126,7 +126,7 @@ const loadingIds = useState(STATE_LOADING_IDS_NAME, () => [loadingId])
 
 // api data
 const achievementUnlockMutation = useAchievementUnlockMutation()
-// const api = getApiData([achievementUnlockMutation])
+// const api = await useApiData([achievementUnlockMutation])
 
 // methods
 const hideScrollHint = () => {

--- a/src/shared/utils/performance.ts
+++ b/src/shared/utils/performance.ts
@@ -1,3 +1,0 @@
-// TODO: actually account for unresolved promises in usages (remove awaits)
-export const zalgo = async <T>(maybePromise: T) =>
-  import.meta.server ? await maybePromise : maybePromise


### PR DESCRIPTION
### 📚 Description

This PR fixes the logic for fetching API data and allows loading API data asynchronously while still synchronously returning the correct HTTP status code from the server.

- the `getApiData` utility is corrected to be an `await`able composable, named `useApiData`
  - the `zalgo` helper is removed as its functionality is now inlined into `useApiData`
- some `defineExpose`s are replaced with alternatives, while other similar transforms are marked as TODO for the future
- the increased type specificity calls for extended use of `readonly`

cc @huzaifaedhi22

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
