### PR TITLE
chore(composables): use global i18n

### DIFF
--- a/src/app/composables/alert.ts
+++ b/src/app/composables/alert.ts
@@ -2,7 +2,7 @@ import { consola } from 'consola'
 import type { SweetAlertIcon, SweetAlertOptions } from 'sweetalert2'
 
 export const useFireAlert = () => {
-  const { t } = useI18n()
+  const { t } = useI18n({ useScope: 'global' })
 
   return async (
     options: SweetAlertOptions & {

--- a/src/app/composables/intl.ts
+++ b/src/app/composables/intl.ts
@@ -1,5 +1,5 @@
 export const useGetCurrencyFormatted = () => {
-  const { locale } = useI18n()
+  const { locale } = useI18n({ useScope: 'global' })
 
   return (number: number) =>
     new Intl.NumberFormat(locale.value, {

--- a/src/app/composables/networking.ts
+++ b/src/app/composables/networking.ts
@@ -34,7 +34,7 @@ export const useHttpStatusCode = async ({
 }: {
   statusCode: number
 }) => {
-  const { locale, t } = useI18n()
+  const { locale, t } = useI18n({ useScope: 'global' })
 
   const { status } = await import('@http-util/status-i18n')
   const statusName = computed(

--- a/src/app/composables/stepper.ts
+++ b/src/app/composables/stepper.ts
@@ -46,7 +46,7 @@ export const useStepperPage = <T extends string>({
   const { error, step, restart } = useStepper<T>({
     initial,
   })
-  const { t } = useI18n()
+  const { t } = useI18n({ useScope: 'global' })
 
   const title = computed(
     () =>


### PR DESCRIPTION
### 📚 Description

Outside of components or pages, the global i18n scope needs to be used.

This PR added an error on duplicate local scope use: https://github.com/intlify/vue-i18n/pull/2204
The error page could also not be rendered due to i18n throwing an error, it appears: https://github.com/nuxt-modules/i18n/issues/3390

cc @huzaifaedhi22 this should fix the new issue that occurred in development only.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
