### PR TITLE
feat(account): block directly from profile

### DIFF
--- a/src/app/components/account/AccountBlockDrawer.vue
+++ b/src/app/components/account/AccountBlockDrawer.vue
@@ -1,0 +1,177 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          {{ t('blockAccountQuestion', { username }) }}
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'success'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="success">
+          <template #description>
+            {{ t('blockAccountConfirmation', { username }) }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <span v-bind="attributes">
+          {{ t('blockAccount') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'success'">
+        <span v-bind="attributes">
+          {{ t('userBlocked') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <span v-bind="attributes">
+          {{ t('error') }}
+        </span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('cancel')"
+          variant="primary"
+          @click="closeDrawer"
+        >
+          {{ t('cancel') }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('confirmBlock')"
+          variant="secondary-critical"
+          @click="blockUser"
+        >
+          {{ t('confirmBlock') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'success'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('backToDashboard')"
+          variant="primary"
+          @click="backToDashboard"
+        >
+          {{ t('backToDashboard') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('restart')"
+          variant="tertiary"
+          @click="restart"
+        >
+          {{ t('restart') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { useCreateAccountBlockMutation } from '~~/gql/documents/mutations/accountBlock/accountBlockCreate'
+
+const { blockedAccountId, username } = defineProps<{
+  blockedAccountId: string
+  username: string
+}>()
+
+const localePath = useLocalePath()
+const { t } = useI18n()
+const store = useStore()
+const wasUserBlocked = ref(false)
+
+const { error, restart, step } = useStepper<'success'>()
+
+const isOpen = defineModel<boolean>('open')
+
+const closeDrawer = () => {
+  isOpen.value = false
+}
+
+const onAnimationEnd = (isOpen: boolean) => {
+  if (isOpen) return
+
+  if (wasUserBlocked.value) {
+    backToDashboard()
+    return
+  }
+
+  step.value = 'default'
+}
+
+const createAccountBlockMutation = useCreateAccountBlockMutation()
+
+const blockUser = async () => {
+  const result = await createAccountBlockMutation.executeMutation({
+    accountBlockInput: {
+      blockedAccountId,
+      createdBy: store.signedInAccountId,
+    },
+  })
+
+  if (result.error) {
+    error.value = result.error
+    return
+  }
+
+  step.value = 'success'
+  wasUserBlocked.value = true
+}
+
+const backToDashboard = async () =>
+  await navigateTo(
+    localePath({
+      name: 'dashboard',
+    }),
+  )
+
+watch(
+  () => error.value,
+  (current) => {
+    if (current) {
+      step.value = 'error'
+    }
+  },
+)
+</script>
+
+<i18n lang="yaml">
+de:
+  backToDashboard: Zurück zum Dashboard
+  blockAccount: Benutzer blockieren
+  blockAccountQuestion: Möchtest du {username} wirklich blockieren? Du wirst keine Einladungen mehr von diesem Benutzer erhalten.
+  blockAccountConfirmation: Der Benutzer {username} wurde blockiert.
+  cancel: Abbrechen
+  confirmBlock: Ja, blockieren
+  error: Fehler
+  restart: Erneut versuchen
+  userBlocked: Benutzer blockiert
+en:
+  backToDashboard: Back to Dashboard
+  blockAccount: Block User
+  blockAccountQuestion: Do you really want to block {username}? You will no longer get invitations from this user.
+  blockAccountConfirmation: The user {username} has been blocked.
+  cancel: Cancel
+  confirmBlock: Yes, block user
+  error: Error
+  restart: Try again
+  userBlocked: User blocked
+</i18n>

--- a/src/app/components/account/AccountDeleteDrawer.vue
+++ b/src/app/components/account/AccountDeleteDrawer.vue
@@ -118,14 +118,6 @@ const { accountId } = defineProps<{
 
 // stepper
 const { error, restart, step } = useStepper<'password' | 'success'>()
-watch(
-  () => error.value,
-  (current) => {
-    if (current) {
-      step.value = 'error'
-    }
-  },
-)
 
 // drawer
 const isOpen = defineModel<boolean>('isOpen')

--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -115,10 +115,16 @@ const isOpen = defineModel<boolean>('open')
 const { step } = useStepper<'reportConfirmation' | 'blockConfirmation'>()
 const onAnimationEnd = (isOpen: boolean) => {
   if (isOpen) return
+
+  if (wasOrganizerBlocked.value) {
+    backToDashboard()
+    return
+  }
   step.value = 'default'
 }
 
 // block
+const wasOrganizerBlocked = ref(false)
 const createAccountBlockMutation = useCreateAccountBlockMutation()
 const api = await useApiData([createAccountBlockMutation])
 const apiErrorMessages = computed(() =>
@@ -151,7 +157,7 @@ const blockOrganizer = async () => {
     })
     return
   }
-
+  wasOrganizerBlocked.value = true
   step.value = 'blockConfirmation'
 }
 const backToDashboard = async () =>

--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -116,15 +116,15 @@ const { step } = useStepper<'reportConfirmation' | 'blockConfirmation'>()
 const onAnimationEnd = (isOpen: boolean) => {
   if (isOpen) return
 
-  if (wasOrganizerBlocked.value) {
+  if (step.value === 'blockConfirmation') {
     backToDashboard()
     return
   }
+
   step.value = 'default'
 }
 
 // block
-const wasOrganizerBlocked = ref(false)
 const createAccountBlockMutation = useCreateAccountBlockMutation()
 const api = await useApiData([createAccountBlockMutation])
 const apiErrorMessages = computed(() =>
@@ -157,7 +157,7 @@ const blockOrganizer = async () => {
     })
     return
   }
-  wasOrganizerBlocked.value = true
+
   step.value = 'blockConfirmation'
 }
 const backToDashboard = async () =>

--- a/src/app/pages/account/view/[username].vue
+++ b/src/app/pages/account/view/[username].vue
@@ -175,6 +175,20 @@
             {{ accountImprint }}
           </TypographyBodyMedium>
         </div>
+        <div v-if="!isOwnProfile" class="flex justify-center">
+          <ButtonColored
+            :aria-label="t('blockAccount')"
+            variant="tertiary-critical"
+            @click="openBlockDrawer"
+          >
+            {{ t('blockAccount') }}
+          </ButtonColored>
+          <AccountBlockDrawer
+            v-model:open="isBlockDrawerOpen"
+            :blocked-account-id="account.id"
+            :username="route.params.username"
+          />
+        </div>
       </div>
     </LayoutPage>
   </Loader>
@@ -280,6 +294,11 @@ if (account.value === null) {
 
 // template
 const localePath = useLocalePath()
+
+const isBlockDrawerOpen = ref<boolean>()
+const openBlockDrawer = () => {
+  isBlockDrawerOpen.value = true
+}
 </script>
 
 <i18n lang="yaml">
@@ -288,6 +307,7 @@ de:
   achievementMeetTheTeam: Triff das Team
   achievements: Errungenschaften
   achievementsNone: Noch keine freigeschaltet
+  blockAccount: Konto blockieren
   contactBook: Kontaktbuch
   edit: Profil bearbeiten
   eventMore: Mehr…
@@ -304,6 +324,7 @@ en:
   achievementMeetTheTeam: Meet the team
   achievements: Achievements
   achievementsNone: None unlocked yet
+  blockAccount: Block Account
   contactBook: Contact Book
   edit: Edit profile
   eventMore: Show more

--- a/src/app/pages/account/view/[username].vue
+++ b/src/app/pages/account/view/[username].vue
@@ -6,20 +6,47 @@
           <TypographyH2>
             {{ title }}
           </TypographyH2>
-          <AppButton
-            v-if="isOwnProfile"
-            :aria-label="t('edit')"
-            :to="
-              localePath({
-                name: 'account-edit-username',
-                params: {
-                  username: store.signedInUsername,
-                },
-              })
-            "
-          >
-            <AppIconSettings class="size-8" />
-          </AppButton>
+          <template v-if="isOwnProfile">
+            <AppButton
+              v-if="isOwnProfile"
+              :aria-label="t('edit')"
+              :to="
+                localePath({
+                  name: 'account-edit-username',
+                  params: {
+                    username: store.signedInUsername,
+                  },
+                })
+              "
+            >
+              <AppIconSettings class="size-8" />
+            </AppButton>
+          </template>
+          <template v-else>
+            <div v-if="store.signedInAccountId" class="flex justify-center">
+              <AppDropdown>
+                <AppDropdownItem
+                  variant="destructive"
+                  @select="isBlockDrawerOpen = true"
+                >
+                  {{ t('blockAccount') }}
+                </AppDropdownItem>
+                <template #trigger>
+                  <span
+                    class="flex size-10.5 items-center justify-center rounded-full bg-(--semantic-base-surface-1)"
+                  >
+                    <AppIconMoreVertical />
+                  </span>
+                </template>
+              </AppDropdown>
+              <AccountBlockDrawer
+                v-model:open="isBlockDrawerOpen"
+                :blocked-account-id="account.id"
+                :blocked-username="route.params.username"
+                :blocking-account-id="store.signedInAccountId"
+              />
+            </div>
+          </template>
         </div>
         <div
           class="flex items-center gap-3 rounded-xl border border-(--semantic-base-line) bg-(--semantic-base-surface-1) p-3 dark:border-none"
@@ -175,20 +202,6 @@
             {{ accountImprint }}
           </TypographyBodyMedium>
         </div>
-        <div v-if="!isOwnProfile" class="flex justify-center">
-          <ButtonColored
-            :aria-label="t('blockAccount')"
-            variant="tertiary-critical"
-            @click="openBlockDrawer"
-          >
-            {{ t('blockAccount') }}
-          </ButtonColored>
-          <AccountBlockDrawer
-            v-model:open="isBlockDrawerOpen"
-            :blocked-account-id="account.id"
-            :username="route.params.username"
-          />
-        </div>
       </div>
     </LayoutPage>
   </Loader>
@@ -294,11 +307,7 @@ if (account.value === null) {
 
 // template
 const localePath = useLocalePath()
-
 const isBlockDrawerOpen = ref<boolean>()
-const openBlockDrawer = () => {
-  isBlockDrawerOpen.value = true
-}
 </script>
 
 <i18n lang="yaml">

--- a/src/app/pages/event/view/[username]/[event_name]/index.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/index.vue
@@ -145,7 +145,7 @@
                   </AppDropdownItem>
                   <template #trigger>
                     <span
-                      class="flex size-10 items-center justify-center rounded-full bg-(--semantic-base-surface-1)"
+                      class="flex size-10.5 items-center justify-center rounded-full bg-(--semantic-base-surface-1)"
                     >
                       <AppIconMoreVertical />
                     </span>


### PR DESCRIPTION
### 📚 Description

This PR
- allows users to block others directly from profile without having to reporting an event
- redirects to dashboard if user blocks an organizer after reporting an event

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
