### PR TITLE
ci(github): set workflow permissions explicitly

### DIFF
--- a/.github/workflows/browserslist-regex.yml
+++ b/.github/workflows/browserslist-regex.yml
@@ -1,5 +1,8 @@
 name: "Browserslist: Regex"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 0 * * 2" # Every Tuesday at 00:00 AM UTC on the default branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -1,5 +1,8 @@
 name: "Release: Scheduled"
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 0 * * 6" # Every Saturday at 00:00 AM UTC on the default branch


### PR DESCRIPTION
### 📚 Description

It's good practice to set the minimal permissions needed for CI workflows.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
