### PR TITLE
test(e2e): reenable ical post test

### DIFF
--- a/tests/e2e/specs/server/ical.spec.ts
+++ b/tests/e2e/specs/server/ical.spec.ts
@@ -1,18 +1,17 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type APIResponse } from '@playwright/test'
 
 test.describe('api load', () => {
-  // TODO: fix linting
-  // test('only allows POST requests', async ({ request }) => {
-  //   const disallowedMethods = ['get', 'put', 'delete', 'patch']
+  test('only allows POST requests', async ({ request }) => {
+    const disallowedMethods = ['get', 'put', 'delete', 'patch']
 
-  //   for (const disallowedMethod of disallowedMethods) {
-  //     const resp = await (
-  //       request[disallowedMethod] as (url: string) => Promise<APIResponse>
-  //     )('/api/model/event/ical')
-  //     expect(resp.status()).toEqual(405)
-  //     expect(resp.statusText()).toEqual('Only POST requests are allowed!')
-  //   }
-  // })
+    for (const disallowedMethod of disallowedMethods) {
+      const resp = await (
+        request[disallowedMethod] as (url: string) => Promise<APIResponse>
+      )('/api/model/event/ical')
+      expect(resp.status()).toEqual(404)
+      expect(resp.statusText()).toEqual('Page not found: /api/model/event/ical')
+    }
+  })
 
   test('validates input data', async ({ request }) => {
     const inputData = [


### PR DESCRIPTION
### 📚 Description

Let's see if we can safely reenable this test.

### 📝 Checklist

<!--
  Put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!

  Examples for Conventional Commits:
  - fix(types): correct array typing
  - feat(component): add button
  - docs(readme): explain setup

  https://conventionalcommits.org
-->

- [x] All commits follow the Conventional Commit format or I'm fine with a squash merge of this PR
- [x] The PR's title follows the Conventional Commit format
