### PR TITLE
fix(dashboard): remove install message

### DIFF
--- a/src/app/components/button/ButtonApp.vue
+++ b/src/app/components/button/ButtonApp.vue
@@ -5,10 +5,10 @@
     :to="localePath('docs-app')"
     variant="secondary"
   >
-    {{ t('appInstall') }}
+    <!-- {{ t('appInstall') }}
     <template #suffix>
       <IHeroiconsArrowRight />
-    </template>
+    </template> -->
   </AppButton>
 </template>
 


### PR DESCRIPTION
The install app message appears on some Android devices where it should not. Until the root cause is found the message is generally removed from the Dashboard page.
