### PR TITLE
fix(reccoom): update return format

### DIFF
--- a/src/app/pages/dashboard/index.vue
+++ b/src/app/pages/dashboard/index.vue
@@ -107,11 +107,11 @@ const {
   const events = (
     await Promise.all(
       eventIds.map(
-        async (eventId) =>
+        async (recommendation) =>
           (
             await $urql.value
               .query(eventQuery, {
-                id: eventId,
+                id: recommendation.event_id,
               })
               .toPromise()
           ).data?.eventByRowId,

--- a/src/server/api/service/reccoom/recommendations.get.ts
+++ b/src/server/api/service/reccoom/recommendations.get.ts
@@ -17,7 +17,9 @@ export default defineEventHandler(async () => {
   }
 
   const baseURL = getServiceHref({ name: 'reccoom', port: 5245 })
-  const recommendations = await $fetch<string[]>('/recommendations', {
+  const recommendations = await $fetch<
+    Array<{ event_id: string; score: number; score_type: string }>
+  >('/recommendations', {
     baseURL,
     headers: {
       cookie: `jwt=${jwt}`,


### PR DESCRIPTION
This pull request updates how recommendations are handled in the dashboard and server API to support richer recommendation objects instead of just event IDs. The changes ensure that each recommendation now includes an `event_id`, `score`, and `score_type`, and the dashboard code is updated to use these new fields.

**API changes:**

* Changed the `/recommendations` API to return an array of objects with `event_id`, `score`, and `score_type` fields instead of just event IDs.

**Dashboard code updates:**

* Updated the dashboard page to map over the new recommendation objects and use `recommendation.event_id` when querying for event details.