### PR TITLE
fix(app): temporarily disable color mode selection for ios

### DIFF
--- a/src/app/pages/session/edit/index.vue
+++ b/src/app/pages/session/edit/index.vue
@@ -35,7 +35,9 @@
       <section class="flex flex-col gap-4">
         <span class="text-lg font-bold">{{ t('display') }}</span>
         <div class="flex flex-col gap-3">
+          <!-- TODO: reenable button for ios once "system" color mode selection works (https://github.com/maevsi/ios/issues/41) -->
           <CardButton
+            v-if="!isIos"
             :title="t('colorScheme')"
             :to="
               localePath({


### PR DESCRIPTION
System color mode selection does not work as expected on ios. Until a proper fix is known, the option to change the color mode in app is hidden on ios.

See https://github.com/maevsi/ios/issues/41.
