### PR TITLE
feat(error): propagate from components to pages

### DIFF
--- a/src/app/components/app/content/AppContent.vue
+++ b/src/app/components/app/content/AppContent.vue
@@ -1,15 +1,5 @@
 <template>
-  <LoaderIndicatorPing v-if="content.pending.value" />
-  <!-- TODO: use v-model error / error boundary -->
-  <AppError
-    v-else-if="content.error.value"
-    :error="{ message: content.error.value.message, status: 500 }"
-  />
-  <AppError
-    v-else-if="!content.data.value"
-    :error="{ message: 'Data is missing', status: 404 }"
-  />
-  <LayoutProse v-else>
+  <LayoutProse v-if="content.data.value">
     <ContentRenderer :value="content.data.value" />
   </LayoutProse>
 </template>

--- a/src/app/components/app/content/AppContentPage.vue
+++ b/src/app/components/app/content/AppContentPage.vue
@@ -1,11 +1,21 @@
 <template>
-  <AppContent :content />
+  <LoaderIndicatorPing v-if="content.pending.value" />
+  <AppError
+    v-else-if="content.error.value"
+    :error="{ message: content.error.value.message, status: 500 }"
+  />
+  <AppError
+    v-else-if="!content.data.value"
+    :error="{ data: { vibetype: t('errorContentMissing') }, status: 404 }"
+  />
+  <AppContent v-else :content />
 </template>
 
 <script setup lang="ts">
 import type { OgImageComponents } from '#og-image/components'
 
 // compiler
+const { t } = useI18n()
 const { path } = defineProps<{
   path: string
 }>()
@@ -23,3 +33,10 @@ if (content.data.value?.ogImage?.component) {
   )
 }
 </script>
+
+<i18n lang="yaml">
+de:
+  errorContentMissing: Der Inhalt ist nicht verfügbar.
+en:
+  errorContentMissing: The content is not available.
+</i18n>

--- a/src/app/components/content/legal/ContentLegalTerms.vue
+++ b/src/app/components/content/legal/ContentLegalTerms.vue
@@ -1,16 +1,7 @@
 <template>
   <LoaderIndicatorPing v-if="pending" />
-  <!-- TODO: replace with model error -->
-  <AppError
-    v-else-if="error"
-    :error="{ message: error.message, status: 500 }"
-  />
-  <AppError
-    v-else-if="!data?.legalTerm"
-    :error="{ message: t('errorUnavailable'), status: 404 }"
-  />
-  <LayoutProse v-else>
-    <MDCRenderer v-if="data.ast" :body="data.ast.body" :data="data.ast.data" />
+  <LayoutProse v-else-if="data?.ast">
+    <MDCRenderer :body="data.ast.body" :data="data.ast.data" />
   </LayoutProse>
 </template>
 
@@ -25,8 +16,10 @@ const emit = defineEmits<{
   id: [string]
 }>()
 
+const modelError = defineModel<Error>('error')
+
 // async data
-const { t, locale } = useI18n()
+const { locale } = useI18n()
 
 const allLegalTermsQuery = graphql(`
   query AllLegalTerms($language: String) {
@@ -45,8 +38,6 @@ const legalTermsQuery = useQuery({
     language: locale.value,
   },
 })
-
-const modelError = defineModel<Error>('error')
 
 const { data, error, pending } = await useAsyncData(
   'content-legal-terms',
@@ -69,18 +60,15 @@ const { data, error, pending } = await useAsyncData(
   },
 )
 
-if (error.value) {
-  modelError.value = error.value // TODO: watch?
-}
+watch(
+  error,
+  (current) => {
+    modelError.value = current ?? undefined
+  },
+  { immediate: true },
+)
 
 if (data.value?.legalTerm) {
   emit('id', data.value.legalTerm.rowId)
 }
 </script>
-
-<i18n lang="yaml">
-de:
-  errorUnavailable: Die Allgemeinen Geschäftsbedingungen sind nicht verfügbar. Bitte melde dies unserem Support.
-en:
-  errorUnavailable: The General Terms and Conditions are unavailable. Please report this to our support.
-</i18n>

--- a/src/app/components/preference/form/PreferenceFormSize.vue
+++ b/src/app/components/preference/form/PreferenceFormSize.vue
@@ -1,11 +1,7 @@
 <template>
   <LoaderIndicatorPing v-if="api.isFetching" />
-  <AppError
-    v-else-if="error"
-    :error="{ message: error.message, status: 500 }"
-  />
   <form
-    v-else
+    v-else-if="!error"
     ref="formRef"
     class="flex flex-col gap-4"
     @submit.prevent="form.handleSubmit"

--- a/src/app/pages/docs/legal/terms/index.vue
+++ b/src/app/pages/docs/legal/terms/index.vue
@@ -1,3 +1,8 @@
 <template>
-  <ContentLegalTerms />
+  <AppError v-if="error" :error="{ message: error.message, status: 500 }" />
+  <ContentLegalTerms v-else v-model:error="error" />
 </template>
+
+<script setup lang="ts">
+const error = ref<Error | undefined>()
+</script>


### PR DESCRIPTION
This pull request refactors how loading and error states are handled across several content and legal terms components. The main changes involve moving the responsibility for displaying loading indicators and error messages from child components to their parent pages, improving separation of concerns and enabling better localization of error messages.

**Error and Loading State Handling**

* Moved the rendering of `LoaderIndicatorPing` and `AppError` components from `AppContent.vue` and `ContentLegalTerms.vue` to their respective parent components (`AppContentPage.vue` and `pages/docs/legal/terms/index.vue`). Now, these parent components manage the display of loading and error states, and only render the content components when data is available.
* Introduced `v-model:error` and `v-model:pending` bindings in `ContentLegalTerms.vue`, allowing parent components to control and react to the error and loading states. Watches are set up to sync these states.

**Localization Improvements**

* Added localized error messages for missing content in `AppContentPage.vue` using the i18n system, making error messages available in both English and German.

**Component Simplification**

* Simplified `ContentLegalTerms.vue` and `AppContent.vue` templates to only render content if data is available, removing redundant error handling logic from these components.
* Removed the error display from `PreferenceFormSize.vue`, so errors are no longer rendered directly in the form component.
