### PR TITLE
fix(urql): invalidate guest cache on createGuests mutation

### DIFF
--- a/src/app/components/form/FormGuest.vue
+++ b/src/app/components/form/FormGuest.vue
@@ -142,7 +142,7 @@ const allContactsQuery = useQuery({
     first: ITEMS_PER_PAGE_LARGE,
   })),
 })
-const createGuestMutation = useMutation(
+const createGuestsMutation = useMutation(
   graphql(`
     mutation CreateGuests($createGuestsInput: CreateGuestsInput!) {
       createGuests(input: $createGuestsInput) {
@@ -154,7 +154,7 @@ const createGuestMutation = useMutation(
     }
   `),
 )
-const apiData = await useApiData([allContactsQuery, createGuestMutation])
+const apiData = await useApiData([allContactsQuery, createGuestsMutation])
 const contacts = computed(
   () =>
     apiData.value.data.allContacts?.nodes
@@ -180,7 +180,7 @@ const form = useForm({
     const successIds: string[] = []
 
     try {
-      const result = await createGuestMutation.executeMutation({
+      const result = await createGuestsMutation.executeMutation({
         createGuestsInput: {
           contactIds: value.contactIds,
           eventId: event.rowId,

--- a/src/shared/utils/urql.ts
+++ b/src/shared/utils/urql.ts
@@ -184,7 +184,7 @@ export const getUrqlClient = async ({
           invalidateCache(cache, 'allEvents')
           invalidateCache(cache, 'eventSearch')
         },
-        createGuest: (_result, _args, cache, _info) =>
+        createGuests: (_result, _args, cache, _info) =>
           invalidateCache(cache, 'allGuests'),
         createEventFavorite: (result, _args, cache, _info) => {
           const newNode = result.createEventFavorite?.eventFavorite


### PR DESCRIPTION
The `createGuests` mutation (added to batch guest/invitation creation into a single request, closing #1654) was left with a stale `createGuest` cache-invalidation key in the urql config, so the cache never actually got invalidated after creating guests. Renamed the key and the related `FormGuest.vue` mutation variable to match.