### PR TITLE
feat(seo): include public events and profiles in sitemap

### DIFF
--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -79,6 +79,6 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   },
   sitemap: {
     credits: false,
-    sources: ['/api/__sitemap__/events'],
+    sources: ['/api/__sitemap__/accounts', '/api/__sitemap__/events'],
   },
 }

--- a/src/config/modules/index.ts
+++ b/src/config/modules/index.ts
@@ -79,5 +79,6 @@ export const modulesConfig: ReturnType<DefineNuxtConfig> = {
   },
   sitemap: {
     credits: false,
+    sources: ['/api/__sitemap__/events'],
   },
 }

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -81,6 +81,7 @@ type Documents = {
   '\n  mutation DeleteDeviceByCreatedByAndFcmToken(\n    $input: DeleteDeviceByCreatedByAndFcmTokenInput!\n  ) {\n    deleteDeviceByCreatedByAndFcmToken(input: $input) {\n      clientMutationId\n    }\n  }\n': typeof types.DeleteDeviceByCreatedByAndFcmTokenDocument
   '\n  query AccountByUsername($username: String!) {\n    accountByUsername(username: $username) {\n      id\n      rowId\n    }\n  }\n': typeof types.AccountByUsernameDocument
   '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n': typeof types.EventByCreatedByAndSlugDocument
+  '\n  query AccountsSitemap($after: Cursor, $first: Int!) {\n    allAccounts(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n': typeof types.AccountsSitemapDocument
   '\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n': typeof types.EventsSitemapDocument
   '\n  mutation JwtCreate($input: JwtCreateInput!) {\n    jwtCreate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n': typeof types.JwtCreateDocument
   '\n  mutation JwtUpdate($input: JwtUpdateInput!) {\n    jwtUpdate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n': typeof types.JwtUpdateDocument
@@ -232,6 +233,8 @@ const documents: Documents = {
     types.AccountByUsernameDocument,
   '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n':
     types.EventByCreatedByAndSlugDocument,
+  '\n  query AccountsSitemap($after: Cursor, $first: Int!) {\n    allAccounts(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n':
+    types.AccountsSitemapDocument,
   '\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n':
     types.EventsSitemapDocument,
   '\n  mutation JwtCreate($input: JwtCreateInput!) {\n    jwtCreate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n':
@@ -680,6 +683,12 @@ export function graphql(
 export function graphql(
   source: '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n',
 ): (typeof documents)['\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query AccountsSitemap($after: Cursor, $first: Int!) {\n    allAccounts(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query AccountsSitemap($after: Cursor, $first: Int!) {\n    allAccounts(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -81,6 +81,7 @@ type Documents = {
   '\n  mutation DeleteDeviceByCreatedByAndFcmToken(\n    $input: DeleteDeviceByCreatedByAndFcmTokenInput!\n  ) {\n    deleteDeviceByCreatedByAndFcmToken(input: $input) {\n      clientMutationId\n    }\n  }\n': typeof types.DeleteDeviceByCreatedByAndFcmTokenDocument
   '\n  query AccountByUsername($username: String!) {\n    accountByUsername(username: $username) {\n      id\n      rowId\n    }\n  }\n': typeof types.AccountByUsernameDocument
   '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n': typeof types.EventByCreatedByAndSlugDocument
+  '\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n': typeof types.EventsSitemapDocument
   '\n  mutation JwtCreate($input: JwtCreateInput!) {\n    jwtCreate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n': typeof types.JwtCreateDocument
   '\n  mutation JwtUpdate($input: JwtUpdateInput!) {\n    jwtUpdate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n': typeof types.JwtUpdateDocument
   '\n  mutation JwtUpdateAttendanceAdd($input: JwtUpdateAttendanceAddInput!) {\n    jwtUpdateAttendanceAdd(input: $input) {\n      result\n    }\n  }\n': typeof types.JwtUpdateAttendanceAddDocument
@@ -231,6 +232,8 @@ const documents: Documents = {
     types.AccountByUsernameDocument,
   '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n':
     types.EventByCreatedByAndSlugDocument,
+  '\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n':
+    types.EventsSitemapDocument,
   '\n  mutation JwtCreate($input: JwtCreateInput!) {\n    jwtCreate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n':
     types.JwtCreateDocument,
   '\n  mutation JwtUpdate($input: JwtUpdateInput!) {\n    jwtUpdate(input: $input) {\n      clientMutationId\n      result\n    }\n  }\n':
@@ -677,6 +680,12 @@ export function graphql(
 export function graphql(
   source: '\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n',
 ): (typeof documents)['\n  query EventByCreatedByAndSlug($createdBy: UUID!, $slug: String!) {\n    eventByCreatedByAndSlug(createdBy: $createdBy, slug: $slug) {\n      id\n    }\n  }\n']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n',
+): (typeof documents)['\n  query EventsSitemap($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {\n      nodes {\n        accountByCreatedBy {\n          username\n        }\n        slug\n        visibility\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1776,6 +1776,22 @@ export type EventByCreatedByAndSlugQuery = {
   eventByCreatedByAndSlug: { id: string } | null
 }
 
+export type EventsSitemapQueryVariables = Exact<{
+  after?: string | null | undefined
+  first: number
+}>
+
+export type EventsSitemapQuery = {
+  allEvents: {
+    nodes: Array<{
+      slug: string
+      visibility: EventVisibility
+      accountByCreatedBy: { username: string } | null
+    }>
+    pageInfo: { endCursor: string | null; hasNextPage: boolean }
+  } | null
+}
+
 export type JwtCreateMutationVariables = Exact<{
   input: JwtCreateInput
 }>
@@ -8623,6 +8639,118 @@ export const EventByCreatedByAndSlugDocument = {
   EventByCreatedByAndSlugQuery,
   EventByCreatedByAndSlugQueryVariables
 >
+export const EventsSitemapDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'EventsSitemap' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'after' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Cursor' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'first' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'allEvents' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'after' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'after' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'first' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'first' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'orderBy' },
+                value: { kind: 'EnumValue', value: 'ROW_ID_ASC' },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'accountByCreatedBy' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'username' },
+                            },
+                          ],
+                        },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'slug' } },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'visibility' },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'pageInfo' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'endCursor' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'hasNextPage' },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EventsSitemapQuery, EventsSitemapQueryVariables>
 export const JwtCreateDocument = {
   kind: 'Document',
   definitions: [

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1776,6 +1776,18 @@ export type EventByCreatedByAndSlugQuery = {
   eventByCreatedByAndSlug: { id: string } | null
 }
 
+export type AccountsSitemapQueryVariables = Exact<{
+  after?: string | null | undefined
+  first: number
+}>
+
+export type AccountsSitemapQuery = {
+  allAccounts: {
+    nodes: Array<{ username: string }>
+    pageInfo: { endCursor: string | null; hasNextPage: boolean }
+  } | null
+}
+
 export type EventsSitemapQueryVariables = Exact<{
   after?: string | null | undefined
   first: number
@@ -8638,6 +8650,107 @@ export const EventByCreatedByAndSlugDocument = {
 } as unknown as DocumentNode<
   EventByCreatedByAndSlugQuery,
   EventByCreatedByAndSlugQueryVariables
+>
+export const AccountsSitemapDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AccountsSitemap' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'after' },
+          },
+          type: { kind: 'NamedType', name: { kind: 'Name', value: 'Cursor' } },
+        },
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'first' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: { kind: 'NamedType', name: { kind: 'Name', value: 'Int' } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'allAccounts' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'after' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'after' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'first' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'first' },
+                },
+              },
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'orderBy' },
+                value: { kind: 'EnumValue', value: 'ROW_ID_ASC' },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'username' },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'pageInfo' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'endCursor' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'hasNextPage' },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  AccountsSitemapQuery,
+  AccountsSitemapQueryVariables
 >
 export const EventsSitemapDocument = {
   kind: 'Document',

--- a/src/server/api/__sitemap__/accounts.get.ts
+++ b/src/server/api/__sitemap__/accounts.get.ts
@@ -37,20 +37,20 @@ const fetchAccountSitemapUrls = async (
 
     if (result.error) throw result.error
 
+    // Postgraphile returns `null` here (not an empty connection) when the
+    // requester can't see any rows, e.g. a database with no accounts yet -
+    // that's a normal empty state, not a failure.
     const connection = result.data?.allAccounts
-    if (!connection) {
-      throw new Error('AccountsSitemap: `allAccounts` was null')
-    }
 
-    for (const node of connection.nodes) {
+    for (const node of connection?.nodes ?? []) {
       urls.push(toSitemapUrl(`/account/view/${node.username}`))
     }
 
-    if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
+    if (connection?.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
       throw new Error('AccountsSitemap: missing endCursor for next page')
     }
 
-    after = connection.pageInfo.hasNextPage
+    after = connection?.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor
       : undefined
   } while (after)

--- a/src/server/api/__sitemap__/accounts.get.ts
+++ b/src/server/api/__sitemap__/accounts.get.ts
@@ -38,12 +38,19 @@ const fetchAccountSitemapUrls = async (
     if (result.error) throw result.error
 
     const connection = result.data?.allAccounts
+    if (!connection) {
+      throw new Error('AccountsSitemap: `allAccounts` was null')
+    }
 
-    for (const node of connection?.nodes ?? []) {
+    for (const node of connection.nodes) {
       urls.push(toSitemapUrl(`/account/view/${node.username}`))
     }
 
-    after = connection?.pageInfo.hasNextPage
+    if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
+      throw new Error('AccountsSitemap: missing endCursor for next page')
+    }
+
+    after = connection.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor
       : undefined
   } while (after)

--- a/src/server/api/__sitemap__/accounts.get.ts
+++ b/src/server/api/__sitemap__/accounts.get.ts
@@ -1,0 +1,62 @@
+import type { H3Event } from 'h3'
+import type { SitemapUrl } from '#sitemap/types'
+
+import { graphql } from '~~/gql/generated'
+
+export const accountsSitemapQuery = graphql(`
+  query AccountsSitemap($after: Cursor, $first: Int!) {
+    allAccounts(after: $after, first: $first, orderBy: ROW_ID_ASC) {
+      nodes {
+        username
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`)
+
+const toSitemapUrl = (loc: string): SitemapUrl => ({
+  loc,
+  _i18nTransform: true,
+})
+
+// Accounts carry no visibility flag, unlike events - a username is public by
+// design, so every account returned here is fair game for the sitemap.
+const fetchAccountSitemapUrls = async (
+  event: H3Event,
+): Promise<SitemapUrl[]> => {
+  const urls: SitemapUrl[] = []
+  let after: string | null | undefined
+
+  do {
+    const result = await event.context.$urql.value
+      .query(accountsSitemapQuery, { after, first: ITEMS_PER_PAGE_LARGE })
+      .toPromise()
+
+    if (result.error) throw result.error
+
+    const connection = result.data?.allAccounts
+
+    for (const node of connection?.nodes ?? []) {
+      urls.push(toSitemapUrl(`/account/view/${node.username}`))
+    }
+
+    after = connection?.pageInfo.hasNextPage
+      ? connection.pageInfo.endCursor
+      : undefined
+  } while (after)
+
+  return urls
+}
+
+// Accounts are stored in the database and change independently of deploys, so
+// they're resolved by this source at runtime instead of being baked into the
+// sitemap at build time. Cached independently of and longer than the sitemap
+// module's own cache to avoid re-querying the backend on every crawl.
+export default defineCachedEventHandler(fetchAccountSitemapUrls, {
+  getKey: () => 'urls',
+  maxAge: 60 * 60 * 24,
+  name: 'sitemap-accounts',
+})

--- a/src/server/api/__sitemap__/events.get.ts
+++ b/src/server/api/__sitemap__/events.get.ts
@@ -42,12 +42,12 @@ const fetchEventSitemapUrls = async (event: H3Event): Promise<SitemapUrl[]> => {
 
     if (result.error) throw result.error
 
+    // Postgraphile returns `null` here (not an empty connection) when the
+    // requester can't see any rows, e.g. a database with no public events
+    // yet - that's a normal empty state, not a failure.
     const connection = result.data?.allEvents
-    if (!connection) {
-      throw new Error('EventsSitemap: `allEvents` was null')
-    }
 
-    for (const node of connection.nodes) {
+    for (const node of connection?.nodes ?? []) {
       const username = node.accountByCreatedBy?.username
 
       if (!username || node.visibility !== EventVisibility.Public) continue
@@ -55,11 +55,11 @@ const fetchEventSitemapUrls = async (event: H3Event): Promise<SitemapUrl[]> => {
       urls.push(toSitemapUrl(`/event/view/${username}/${node.slug}`))
     }
 
-    if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
+    if (connection?.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
       throw new Error('EventsSitemap: missing endCursor for next page')
     }
 
-    after = connection.pageInfo.hasNextPage
+    after = connection?.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor
       : undefined
   } while (after)

--- a/src/server/api/__sitemap__/events.get.ts
+++ b/src/server/api/__sitemap__/events.get.ts
@@ -43,8 +43,11 @@ const fetchEventSitemapUrls = async (event: H3Event): Promise<SitemapUrl[]> => {
     if (result.error) throw result.error
 
     const connection = result.data?.allEvents
+    if (!connection) {
+      throw new Error('EventsSitemap: `allEvents` was null')
+    }
 
-    for (const node of connection?.nodes ?? []) {
+    for (const node of connection.nodes) {
       const username = node.accountByCreatedBy?.username
 
       if (!username || node.visibility !== EventVisibility.Public) continue
@@ -52,7 +55,11 @@ const fetchEventSitemapUrls = async (event: H3Event): Promise<SitemapUrl[]> => {
       urls.push(toSitemapUrl(`/event/view/${username}/${node.slug}`))
     }
 
-    after = connection?.pageInfo.hasNextPage
+    if (connection.pageInfo.hasNextPage && !connection.pageInfo.endCursor) {
+      throw new Error('EventsSitemap: missing endCursor for next page')
+    }
+
+    after = connection.pageInfo.hasNextPage
       ? connection.pageInfo.endCursor
       : undefined
   } while (after)

--- a/src/server/api/__sitemap__/events.get.ts
+++ b/src/server/api/__sitemap__/events.get.ts
@@ -1,0 +1,71 @@
+import type { H3Event } from 'h3'
+import type { SitemapUrl } from '#sitemap/types'
+
+import { graphql } from '~~/gql/generated'
+import { EventVisibility } from '~~/gql/generated/graphcache'
+
+export const eventsSitemapQuery = graphql(`
+  query EventsSitemap($after: Cursor, $first: Int!) {
+    allEvents(after: $after, first: $first, orderBy: ROW_ID_ASC) {
+      nodes {
+        accountByCreatedBy {
+          username
+        }
+        slug
+        visibility
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`)
+
+const toSitemapUrl = (loc: string): SitemapUrl => ({
+  loc,
+  _i18nTransform: true,
+})
+
+// Postgraphile's row-level security already scopes `allEvents` to what an
+// anonymous requester (no cookie is forwarded here) may see, i.e. public
+// events only. `visibility` is still checked defensively so a backend change
+// can't silently leak unlisted/private event URLs into the sitemap.
+const fetchEventSitemapUrls = async (event: H3Event): Promise<SitemapUrl[]> => {
+  const urls: SitemapUrl[] = []
+  let after: string | null | undefined
+
+  do {
+    const result = await event.context.$urql.value
+      .query(eventsSitemapQuery, { after, first: ITEMS_PER_PAGE_LARGE })
+      .toPromise()
+
+    if (result.error) throw result.error
+
+    const connection = result.data?.allEvents
+
+    for (const node of connection?.nodes ?? []) {
+      const username = node.accountByCreatedBy?.username
+
+      if (!username || node.visibility !== EventVisibility.Public) continue
+
+      urls.push(toSitemapUrl(`/event/view/${username}/${node.slug}`))
+    }
+
+    after = connection?.pageInfo.hasNextPage
+      ? connection.pageInfo.endCursor
+      : undefined
+  } while (after)
+
+  return urls
+}
+
+// Events are stored in the database and change independently of deploys, so
+// they're resolved by this source at runtime instead of being baked into the
+// sitemap at build time. Cached independently of and longer than the sitemap
+// module's own cache to avoid re-querying the backend on every crawl.
+export default defineCachedEventHandler(fetchEventSitemapUrls, {
+  getKey: () => 'urls',
+  maxAge: 60 * 60 * 24,
+  name: 'sitemap-events',
+})

--- a/tests/e2e/specs/server/sitemap.spec.ts
+++ b/tests/e2e/specs/server/sitemap.spec.ts
@@ -23,12 +23,32 @@ test.describe('sitemap', () => {
     for (const language of languages) {
       const resp = await request.get(`/__sitemap__/${language}.xml`)
       const text = (await resp.text())
+        // Public event URLs depend on whatever's in the database during this
+        // run (shared with other specs), so they aren't stable across runs -
+        // only the static route set is asserted against the snapshot here.
+        .replaceAll(/ {4}<url>[\s\S]*?<\/url>\n/g, (urlBlock) =>
+          urlBlock.includes('/event/view/') ? '' : urlBlock,
+        )
         .replaceAll(/\n.+<\/lastmod>/g, '')
         .replaceAll(SITE_URL, 'https://example.com')
 
       expect(text).toMatchSnapshot(
         `sitemap-content-${process.env.VIO_SERVER}-${language}.txt`,
       )
+    }
+  })
+
+  test('events source', async ({ request }) => {
+    const resp = await request.get('/api/__sitemap__/events')
+
+    expect(resp.ok()).toBeTruthy()
+
+    const urls: unknown = await resp.json()
+
+    expect(Array.isArray(urls)).toBe(true)
+
+    for (const url of urls as { loc: string }[]) {
+      expect(url.loc).toMatch(/^\/event\/view\/[^/]+\/[^/]+$/)
     }
   })
 })

--- a/tests/e2e/specs/server/sitemap.spec.ts
+++ b/tests/e2e/specs/server/sitemap.spec.ts
@@ -23,11 +23,15 @@ test.describe('sitemap', () => {
     for (const language of languages) {
       const resp = await request.get(`/__sitemap__/${language}.xml`)
       const text = (await resp.text())
-        // Public event URLs depend on whatever's in the database during this
-        // run (shared with other specs), so they aren't stable across runs -
-        // only the static route set is asserted against the snapshot here.
+        // Public event and account URLs depend on whatever's in the database
+        // during this run (shared with other specs), so they aren't stable
+        // across runs - only the static route set is asserted against the
+        // snapshot here.
         .replaceAll(/ {4}<url>[\s\S]*?<\/url>\n/g, (urlBlock) =>
-          urlBlock.includes('/event/view/') ? '' : urlBlock,
+          urlBlock.includes('/event/view/') ||
+          urlBlock.includes('/account/view/')
+            ? ''
+            : urlBlock,
         )
         .replaceAll(/\n.+<\/lastmod>/g, '')
         .replaceAll(SITE_URL, 'https://example.com')
@@ -49,6 +53,20 @@ test.describe('sitemap', () => {
 
     for (const url of urls as { loc: string }[]) {
       expect(url.loc).toMatch(/^\/event\/view\/[^/]+\/[^/]+$/)
+    }
+  })
+
+  test('accounts source', async ({ request }) => {
+    const resp = await request.get('/api/__sitemap__/accounts')
+
+    expect(resp.ok()).toBeTruthy()
+
+    const urls: unknown = await resp.json()
+
+    expect(Array.isArray(urls)).toBe(true)
+
+    for (const url of urls as { loc: string }[]) {
+      expect(url.loc).toMatch(/^\/account\/view\/[^/]+$/)
     }
   })
 })


### PR DESCRIPTION
Public event pages (`/event/view/{username}/{slug}`) and account profiles (`/account/view/{username}`) were invisible to search engines. The sitemap only reflected Nuxt's static page tree, not database content, so only chrome and marketing pages ever got indexed.

Adds two sitemap sources, `/api/__sitemap__/events` and `/api/__sitemap__/accounts`, that query public data from Postgraphile and feed it into the sitemap as their own chunked sitemaps (`events-0.xml`, `accounts-0.xml`, ...), separate from the app's static `pages` sitemap. Events rely on Postgraphile's row-level security to scope anonymous requests to public events, with a defensive `visibility` check as a backstop. Accounts carry no visibility flag (a username is public by design), so every account is included. Both are cached for 24 hours so the database isn't hit on every crawl.

Closes #1041. The issue's other two asks are covered separately: the original "sitemap leaks auth-only pages" complaint no longer applies (the module and per-page `robots: false` opt-outs already handle it), and pinging search engines is out of scope, explained in a comment on the issue.
