### PR TITLE
feat(event): allow setting categories and formats

### DIFF
--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -410,6 +410,11 @@ const deleteEventCategoryMappingByEventIdAndCategoryIdMutation = useMutation(
     ) {
       deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {
         deletedEventCategoryMappingId
+        eventCategoryMapping {
+          eventByEventId {
+            id
+          }
+        }
       }
     }
   `),
@@ -436,6 +441,11 @@ const deleteEventFormatMappingByEventIdAndFormatIdMutation = useMutation(
     ) {
       deleteEventFormatMappingByEventIdAndFormatId(input: $input) {
         deletedEventFormatMappingId
+        eventFormatMapping {
+          eventByEventId {
+            id
+          }
+        }
       }
     }
   `),
@@ -492,7 +502,7 @@ const syncEventCategoryMappings = async ({
   originalCategoryIds: string[]
   selectedCategoryIds: string[]
 }) => {
-  await Promise.all([
+  const results = await Promise.all([
     ...selectedCategoryIds
       .filter((categoryId) => !originalCategoryIds.includes(categoryId))
       .map((categoryId) =>
@@ -508,6 +518,8 @@ const syncEventCategoryMappings = async ({
         ),
       ),
   ])
+
+  return results.every((result) => !result.error)
 }
 const syncEventFormatMappings = async ({
   eventId,
@@ -518,7 +530,7 @@ const syncEventFormatMappings = async ({
   originalFormatIds: string[]
   selectedFormatIds: string[]
 }) => {
-  await Promise.all([
+  const results = await Promise.all([
     ...selectedFormatIds
       .filter((formatId) => !originalFormatIds.includes(formatId))
       .map((formatId) =>
@@ -534,6 +546,8 @@ const syncEventFormatMappings = async ({
         }),
       ),
   ])
+
+  return results.every((result) => !result.error)
 }
 
 const form = useForm({
@@ -592,7 +606,7 @@ const form = useForm({
 
       if (!getResultData(result)) return
 
-      await syncEventCategoryMappings({
+      const categoryMappingsSynced = await syncEventCategoryMappings({
         eventId: value.rowId,
         originalCategoryIds:
           event?.eventCategoryMappingsByEventId?.nodes
@@ -600,7 +614,7 @@ const form = useForm({
             .map((node) => node.categoryId) ?? [],
         selectedCategoryIds: value.categoryIds,
       })
-      await syncEventFormatMappings({
+      const formatMappingsSynced = await syncEventFormatMappings({
         eventId: value.rowId,
         originalFormatIds:
           event?.eventFormatMappingsByEventId?.nodes
@@ -608,6 +622,7 @@ const form = useForm({
             .map((node) => node.formatId) ?? [],
         selectedFormatIds: value.formatIds,
       })
+      if (!categoryMappingsSynced || !formatMappingsSynced) return
 
       toast.success(t('eventUpdateSuccess'))
     } else {
@@ -637,16 +652,17 @@ const form = useForm({
 
       const eventId = data.createEvent?.event?.rowId
       if (eventId) {
-        await syncEventCategoryMappings({
+        const categoryMappingsSynced = await syncEventCategoryMappings({
           eventId,
           originalCategoryIds: [],
           selectedCategoryIds: value.categoryIds,
         })
-        await syncEventFormatMappings({
+        const formatMappingsSynced = await syncEventFormatMappings({
           eventId,
           originalFormatIds: [],
           selectedFormatIds: value.formatIds,
         })
+        if (!categoryMappingsSynced || !formatMappingsSynced) return
       }
 
       toast.success(t('eventCreateSuccess'))

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -86,6 +86,28 @@
             />
           </Field>
         </form.Field>
+        <form.Field v-slot="{ field }" name="categoryIds">
+          <Field>
+            <FieldLabel>{{ t('categories') }}</FieldLabel>
+            <FieldContent>
+              <FormEventCategorySelect
+                :model-value="field.state.value"
+                @update:model-value="field.handleChange($event)"
+              />
+            </FieldContent>
+          </Field>
+        </form.Field>
+        <form.Field v-slot="{ field }" name="formatIds">
+          <Field>
+            <FieldLabel>{{ t('formats') }}</FieldLabel>
+            <FieldContent>
+              <FormEventFormatSelect
+                :model-value="field.state.value"
+                @update:model-value="field.handleChange($event)"
+              />
+            </FieldContent>
+          </Field>
+        </form.Field>
         <form.Field
           v-if="form.getFieldValue('visibility') === EventVisibility.Public"
           v-slot="{ field }"
@@ -319,7 +341,14 @@ const { event = undefined } = defineProps<{
     | 'url'
     | 'description'
     | 'rowId'
-  >
+  > & {
+    eventCategoryMappingsByEventId?: {
+      nodes: readonly { categoryId: string }[]
+    } | null
+    eventFormatMappingsByEventId?: {
+      nodes: readonly { formatId: string }[]
+    } | null
+  }
 }>()
 
 const localePath = useLocalePath()
@@ -340,6 +369,7 @@ const createEventMutation = useMutation(
       createEvent(input: $input) {
         event {
           id
+          rowId
         }
       }
     }
@@ -356,7 +386,68 @@ const updateEventMutation = useMutation(
     }
   `),
 )
-const api = await useApiData([createEventMutation, updateEventMutation])
+const createEventCategoryMappingMutation = useMutation(
+  graphql(`
+    mutation CreateEventCategoryMapping(
+      $input: CreateEventCategoryMappingInput!
+    ) {
+      createEventCategoryMapping(input: $input) {
+        eventCategoryMapping {
+          categoryId
+          eventByEventId {
+            id
+          }
+          id
+        }
+      }
+    }
+  `),
+)
+const deleteEventCategoryMappingByEventIdAndCategoryIdMutation = useMutation(
+  graphql(`
+    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(
+      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!
+    ) {
+      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {
+        deletedEventCategoryMappingId
+      }
+    }
+  `),
+)
+const createEventFormatMappingMutation = useMutation(
+  graphql(`
+    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {
+      createEventFormatMapping(input: $input) {
+        eventFormatMapping {
+          eventByEventId {
+            id
+          }
+          formatId
+          id
+        }
+      }
+    }
+  `),
+)
+const deleteEventFormatMappingByEventIdAndFormatIdMutation = useMutation(
+  graphql(`
+    mutation DeleteEventFormatMappingByEventIdAndFormatId(
+      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!
+    ) {
+      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {
+        deletedEventFormatMappingId
+      }
+    }
+  `),
+)
+const api = await useApiData([
+  createEventMutation,
+  updateEventMutation,
+  createEventCategoryMappingMutation,
+  deleteEventCategoryMappingByEventIdAndCategoryIdMutation,
+  createEventFormatMappingMutation,
+  deleteEventFormatMappingByEventIdAndFormatIdMutation,
+])
 
 // slug validation
 const validateEventSlugFn = async (value: string) => {
@@ -377,8 +468,10 @@ const validateEventSlugFn = async (value: string) => {
 
 // form
 const formSchema = z.object({
+  categoryIds: z.array(z.string()),
   description: SCHEMA_EVENT_DESCRIPTION_OPTIONAL,
   end: z.string(),
+  formatIds: z.array(z.string()),
   guestCountMaximum: z.string(),
   isInPerson: z.boolean(),
   isRemote: z.boolean(),
@@ -390,10 +483,71 @@ const formSchema = z.object({
   visibility: z.enum(EventVisibility),
 })
 
+const syncEventCategoryMappings = async ({
+  eventId,
+  originalCategoryIds,
+  selectedCategoryIds,
+}: {
+  eventId: string
+  originalCategoryIds: string[]
+  selectedCategoryIds: string[]
+}) => {
+  await Promise.all([
+    ...selectedCategoryIds
+      .filter((categoryId) => !originalCategoryIds.includes(categoryId))
+      .map((categoryId) =>
+        createEventCategoryMappingMutation.executeMutation({
+          input: { eventCategoryMapping: { categoryId, eventId } },
+        }),
+      ),
+    ...originalCategoryIds
+      .filter((categoryId) => !selectedCategoryIds.includes(categoryId))
+      .map((categoryId) =>
+        deleteEventCategoryMappingByEventIdAndCategoryIdMutation.executeMutation(
+          { input: { categoryId, eventId } },
+        ),
+      ),
+  ])
+}
+const syncEventFormatMappings = async ({
+  eventId,
+  originalFormatIds,
+  selectedFormatIds,
+}: {
+  eventId: string
+  originalFormatIds: string[]
+  selectedFormatIds: string[]
+}) => {
+  await Promise.all([
+    ...selectedFormatIds
+      .filter((formatId) => !originalFormatIds.includes(formatId))
+      .map((formatId) =>
+        createEventFormatMappingMutation.executeMutation({
+          input: { eventFormatMapping: { eventId, formatId } },
+        }),
+      ),
+    ...originalFormatIds
+      .filter((formatId) => !selectedFormatIds.includes(formatId))
+      .map((formatId) =>
+        deleteEventFormatMappingByEventIdAndFormatIdMutation.executeMutation({
+          input: { eventId, formatId },
+        }),
+      ),
+  ])
+}
+
 const form = useForm({
   defaultValues: {
+    categoryIds:
+      event?.eventCategoryMappingsByEventId?.nodes
+        .filter(isNeitherNullNorUndefined)
+        .map((node) => node.categoryId) ?? [],
     description: (event?.description as string) ?? '',
     end: (event?.end as string) ?? '',
+    formatIds:
+      event?.eventFormatMappingsByEventId?.nodes
+        .filter(isNeitherNullNorUndefined)
+        .map((node) => node.formatId) ?? [],
     guestCountMaximum: event?.guestCountMaximum
       ? String(event.guestCountMaximum)
       : '',
@@ -438,6 +592,23 @@ const form = useForm({
 
       if (!getResultData(result)) return
 
+      await syncEventCategoryMappings({
+        eventId: value.rowId,
+        originalCategoryIds:
+          event?.eventCategoryMappingsByEventId?.nodes
+            .filter(isNeitherNullNorUndefined)
+            .map((node) => node.categoryId) ?? [],
+        selectedCategoryIds: value.categoryIds,
+      })
+      await syncEventFormatMappings({
+        eventId: value.rowId,
+        originalFormatIds:
+          event?.eventFormatMappingsByEventId?.nodes
+            .filter(isNeitherNullNorUndefined)
+            .map((node) => node.formatId) ?? [],
+        selectedFormatIds: value.formatIds,
+      })
+
       toast.success(t('eventUpdateSuccess'))
     } else {
       // Add
@@ -461,7 +632,22 @@ const form = useForm({
         },
       })
 
-      if (!getResultData(result)) return
+      const data = getResultData(result)
+      if (!data) return
+
+      const eventId = data.createEvent?.event?.rowId
+      if (eventId) {
+        await syncEventCategoryMappings({
+          eventId,
+          originalCategoryIds: [],
+          selectedCategoryIds: value.categoryIds,
+        })
+        await syncEventFormatMappings({
+          eventId,
+          originalFormatIds: [],
+          selectedFormatIds: value.formatIds,
+        })
+      }
 
       toast.success(t('eventCreateSuccess'))
 
@@ -530,12 +716,14 @@ if (event?.rowId) {
 <i18n lang="yaml">
 de:
   attendanceType: Anwesenheitstyp
+  categories: Kategorien
   description: Einladungstext
   end: Ende
   eventCreate: Veranstaltung erstellen
   eventCreateSuccess: Veranstaltung erfolgreich erstellt.
   eventUpdate: Änderungen speichern
   eventUpdateSuccess: Aktualisiert
+  formats: Formate
   # stateInfoLocation: Ein Suchbegriff für Google Maps.
   isInPerson: vor Ort
   isRemote: digital
@@ -553,12 +741,14 @@ de:
   url: Weblink
 en:
   attendanceType: Attendance type
+  categories: Categories
   description: Invitation text
   end: End
   eventCreate: Create event
   eventCreateSuccess: Event created successfully.
   eventUpdate: Save changes
   eventUpdateSuccess: Updated
+  formats: Formats
   # stateInfoLocation: A search phrase for Google Maps.
   isInPerson: in person
   isRemote: remote

--- a/src/app/components/form/FormEventCategorySelect.vue
+++ b/src/app/components/form/FormEventCategorySelect.vue
@@ -1,0 +1,152 @@
+<template>
+  <ul class="flex flex-wrap gap-5">
+    <li v-for="eventCategory in eventCategories" :key="eventCategory.rowId">
+      <PreferenceElement
+        v-if="eventCategory.label"
+        :id="eventCategory.rowId"
+        :name="eventCategory.label"
+        :selected="modelValue"
+        @click="toggle(eventCategory.rowId)"
+      >
+        <AppIconPreferenceCategoryArtAndCulture
+          v-if="eventCategory.name === 'art-and-culture'"
+        />
+        <AppIconPreferenceCategoryBusiness
+          v-else-if="eventCategory.name === 'business'"
+        />
+        <AppIconPreferenceCategoryComedy
+          v-else-if="eventCategory.name === 'comedy'"
+        />
+        <AppIconPreferenceCategoryEducation
+          v-else-if="eventCategory.name === 'education'"
+        />
+        <AppIconPreferenceCategoryFashionAndLifestyle
+          v-else-if="eventCategory.name === 'fashion-and-lifestyle'"
+        />
+        <AppIconPreferenceCategoryFoodAndDrink
+          v-else-if="eventCategory.name === 'food-and-drink'"
+        />
+        <AppIconPreferenceCategoryLiterature
+          v-else-if="eventCategory.name === 'literature'"
+        />
+        <AppIconPreferenceCategoryMusicAndEntertainment
+          v-else-if="eventCategory.name === 'music-and-entertainment'"
+        />
+        <AppIconPreferenceCategoryPolitics
+          v-else-if="eventCategory.name === 'politics'"
+        />
+        <AppIconPreferenceCategorySocial
+          v-else-if="eventCategory.name === 'social'"
+        />
+        <AppIconPreferenceCategorySportsAndFitness
+          v-else-if="eventCategory.name === 'sports-and-fitness'"
+        />
+        <AppIconPreferenceOther v-else-if="eventCategory.name === 'other'" />
+      </PreferenceElement>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { useQuery } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+
+const modelValue = defineModel<string[]>({ default: () => [] })
+
+// template
+const { t } = useI18n()
+const translate = (nameKey: string) => {
+  switch (nameKey) {
+    case 'art-and-culture':
+      return t('categoryArtAndCulture')
+    case 'business':
+      return t('categoryBusiness')
+    case 'comedy':
+      return t('categoryComedy')
+    case 'education':
+      return t('categoryEducation')
+    case 'fashion-and-lifestyle':
+      return t('categoryFashionAndLifestyle')
+    case 'food-and-drink':
+      return t('categoryFoodAndDrink')
+    case 'literature':
+      return t('categoryLiterature')
+    case 'music-and-entertainment':
+      return t('categoryMusicAndEntertainment')
+    case 'other':
+      return t('categoryOther')
+    case 'politics':
+      return t('categoryPolitics')
+    case 'social':
+      return t('categorySocial')
+    case 'sports-and-fitness':
+      return t('categorySportsAndFitness')
+    default:
+      return undefined
+  }
+}
+
+// api data
+const allEventCategoriesQuery = useQuery({
+  query: graphql(`
+    query AllEventCategoriesFormEvent {
+      allEventCategories {
+        nodes {
+          id
+          name
+          rowId
+        }
+      }
+    }
+  `),
+})
+const api = await useApiData([allEventCategoriesQuery])
+
+const eventCategories = computed(() =>
+  api.value.data.allEventCategories?.nodes
+    .filter(isNeitherNullNorUndefined)
+    .map((item) => ({ ...item, label: translate(item.name) }))
+    .sort((a, b) => {
+      if (a.name === 'other') return 1
+      if (b.name === 'other') return -1
+      return a.name.localeCompare(b.name)
+    }),
+)
+
+// methods
+const toggle = (categoryId: string) => {
+  modelValue.value = modelValue.value.includes(categoryId)
+    ? modelValue.value.filter((id) => id !== categoryId)
+    : [...modelValue.value, categoryId]
+}
+</script>
+
+<i18n lang="yaml">
+de:
+  categoryArtAndCulture: Kunst & Kultur
+  categoryBusiness: Wirtschaft
+  categoryComedy: Komödie
+  categoryEducation: Bildung
+  categoryFashionAndLifestyle: Mode & Lifestyle
+  categoryFoodAndDrink: Essen & Trinken
+  categoryLiterature: Literatur
+  categoryMusicAndEntertainment: Musik & Unterhaltung
+  categoryOther: Andere
+  categoryPolitics: Politik
+  categorySocial: Soziales
+  categorySportsAndFitness: Sport & Fitness
+en:
+  categoryArtAndCulture: Art & Culture
+  categoryBusiness: Business
+  categoryComedy: Comedy
+  categoryEducation: Education
+  categoryFashionAndLifestyle: Fashion & Lifestyle
+  categoryFoodAndDrink: Food & Drink
+  categoryLiterature: Literature
+  categoryMusicAndEntertainment: Music & Entertainment
+  categoryOther: Other
+  categoryPolitics: Politics
+  categorySocial: Social
+  categorySportsAndFitness: Sports & Fitness
+</i18n>

--- a/src/app/components/form/FormEventFormatSelect.vue
+++ b/src/app/components/form/FormEventFormatSelect.vue
@@ -1,0 +1,152 @@
+<template>
+  <ul class="flex flex-wrap gap-5">
+    <li v-for="eventFormat in eventFormats" :key="eventFormat.rowId">
+      <PreferenceElement
+        v-if="eventFormat.label"
+        :id="eventFormat.rowId"
+        :name="eventFormat.label"
+        :selected="modelValue"
+        @click="toggle(eventFormat.rowId)"
+      >
+        <AppIconPreferenceFormatConference
+          v-if="eventFormat.name === 'conference'"
+        />
+        <AppIconPreferenceFormatDemonstration
+          v-else-if="eventFormat.name === 'demo'"
+        />
+        <AppIconPreferenceFormatExhibition
+          v-else-if="eventFormat.name === 'exhibition'"
+        />
+        <AppIconPreferenceFormatFestival
+          v-else-if="eventFormat.name === 'festival'"
+        />
+        <AppIconPreferenceFormatHackathon
+          v-else-if="eventFormat.name === 'hackathon'"
+        />
+        <AppIconPreferenceFormatLecture
+          v-else-if="eventFormat.name === 'lecture'"
+        />
+        <AppIconPreferenceFormatLivePerformance
+          v-else-if="eventFormat.name === 'live-performance'"
+        />
+        <AppIconPreferenceFormatMeetup
+          v-else-if="eventFormat.name === 'meetup'"
+        />
+        <AppIconPreferenceFormatParty
+          v-else-if="eventFormat.name === 'party'"
+        />
+        <AppIconPreferenceFormatSeminar
+          v-else-if="eventFormat.name === 'seminar'"
+        />
+        <AppIconPreferenceFormatWorkshop
+          v-else-if="eventFormat.name === 'workshop'"
+        />
+        <AppIconPreferenceOther v-else-if="eventFormat.name === 'other'" />
+      </PreferenceElement>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { useQuery } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+
+const modelValue = defineModel<string[]>({ default: () => [] })
+
+// template
+const { t } = useI18n()
+const translate = (nameKey: string) => {
+  switch (nameKey) {
+    case 'conference':
+      return t('formatConference')
+    case 'demo':
+      return t('formatDemonstration')
+    case 'exhibition':
+      return t('formatExhibition')
+    case 'festival':
+      return t('formatFestival')
+    case 'hackathon':
+      return t('formatHackathon')
+    case 'lecture':
+      return t('formatLecture')
+    case 'live-performance':
+      return t('formatLivePerformance')
+    case 'meetup':
+      return t('formatMeetup')
+    case 'other':
+      return t('formatOther')
+    case 'party':
+      return t('formatParty')
+    case 'seminar':
+      return t('formatSeminar')
+    case 'workshop':
+      return t('formatWorkshop')
+    default:
+      return undefined
+  }
+}
+
+// api data
+const allEventFormatsQuery = useQuery({
+  query: graphql(`
+    query AllEventFormatsFormEvent {
+      allEventFormats {
+        nodes {
+          id
+          name
+          rowId
+        }
+      }
+    }
+  `),
+})
+const api = await useApiData([allEventFormatsQuery])
+
+const eventFormats = computed(() =>
+  api.value.data.allEventFormats?.nodes
+    .filter(isNeitherNullNorUndefined)
+    .map((item) => ({ ...item, label: translate(item.name) }))
+    .sort((a, b) => {
+      if (a.name === 'other') return 1
+      if (b.name === 'other') return -1
+      return a.name.localeCompare(b.name)
+    }),
+)
+
+// methods
+const toggle = (formatId: string) => {
+  modelValue.value = modelValue.value.includes(formatId)
+    ? modelValue.value.filter((id) => id !== formatId)
+    : [...modelValue.value, formatId]
+}
+</script>
+
+<i18n lang="yaml">
+de:
+  formatConference: Konferenz
+  formatDemonstration: Demonstration
+  formatExhibition: Ausstellung
+  formatFestival: Festival
+  formatHackathon: Hackathon
+  formatLecture: Vortrag
+  formatLivePerformance: Live-Auftritt
+  formatMeetup: Meetup
+  formatOther: Andere
+  formatParty: Party
+  formatSeminar: Seminar
+  formatWorkshop: Workshop
+en:
+  formatConference: Conference
+  formatDemonstration: Demonstration
+  formatExhibition: Exhibition
+  formatFestival: Festival
+  formatHackathon: Hackathon
+  formatLecture: Lecture
+  formatLivePerformance: Live Performance
+  formatMeetup: Meetup
+  formatOther: Other
+  formatParty: Party
+  formatSeminar: Seminar
+  formatWorkshop: Workshop
+</i18n>

--- a/src/app/pages/event/edit/[username]/[event_name].vue
+++ b/src/app/pages/event/edit/[username]/[event_name].vue
@@ -51,6 +51,18 @@ const eventQuery = useQuery({
             createdBy
             description
             end
+            eventCategoryMappingsByEventId {
+              nodes {
+                categoryId
+                id
+              }
+            }
+            eventFormatMappingsByEventId {
+              nodes {
+                formatId
+                id
+              }
+            }
             id
             guestCountMaximum
             isArchived

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -33,9 +33,9 @@ type Documents = {
   '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.CreateEventDocument
   '\n    mutation updateEventByRowId($input: UpdateEventByRowIdInput!) {\n      updateEventByRowId(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ': typeof types.UpdateEventByRowIdDocument
   '\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ': typeof types.CreateEventCategoryMappingDocument
-  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ': typeof types.DeleteEventCategoryMappingByEventIdAndCategoryIdDocument
+  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n        eventCategoryMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ': typeof types.DeleteEventCategoryMappingByEventIdAndCategoryIdDocument
   '\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ': typeof types.CreateEventFormatMappingDocument
-  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ': typeof types.DeleteEventFormatMappingByEventIdAndFormatIdDocument
+  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ': typeof types.DeleteEventFormatMappingByEventIdAndFormatIdDocument
   '\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllEventCategoriesFormEventDocument
   '\n    query AllEventFormatsFormEvent {\n      allEventFormats {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllEventFormatsFormEventDocument
   '\n    mutation CreateGuests($createGuestsInput: CreateGuestsInput!) {\n      createGuests(input: $createGuestsInput) {\n        result {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.CreateGuestsDocument
@@ -141,11 +141,11 @@ const documents: Documents = {
     types.UpdateEventByRowIdDocument,
   '\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ':
     types.CreateEventCategoryMappingDocument,
-  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ':
+  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n        eventCategoryMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ':
     types.DeleteEventCategoryMappingByEventIdAndCategoryIdDocument,
   '\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ':
     types.CreateEventFormatMappingDocument,
-  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ':
+  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ':
     types.DeleteEventFormatMappingByEventIdAndFormatIdDocument,
   '\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ':
     types.AllEventCategoriesFormEventDocument,
@@ -411,8 +411,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ']
+  source: '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n        eventCategoryMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n        eventCategoryMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -423,8 +423,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ']
+  source: '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -30,8 +30,14 @@ type Documents = {
   '\n    mutation CreateReport($input: CreateReportInput!) {\n      createReport(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.CreateReportDocument
   '\n    mutation CreateContact($input: CreateContactInput!) {\n      createContact(input: $input) {\n        contact {\n          id\n        }\n      }\n    }\n  ': typeof types.CreateContactDocument
   '\n    mutation UpdateContactByRowId($input: UpdateContactByRowIdInput!) {\n      updateContactByRowId(input: $input) {\n        contact {\n          ...ContactItem\n        }\n      }\n    }\n  ': typeof types.UpdateContactByRowIdDocument
-  '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ': typeof types.CreateEventDocument
+  '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.CreateEventDocument
   '\n    mutation updateEventByRowId($input: UpdateEventByRowIdInput!) {\n      updateEventByRowId(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ': typeof types.UpdateEventByRowIdDocument
+  '\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ': typeof types.CreateEventCategoryMappingDocument
+  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ': typeof types.DeleteEventCategoryMappingByEventIdAndCategoryIdDocument
+  '\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ': typeof types.CreateEventFormatMappingDocument
+  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ': typeof types.DeleteEventFormatMappingByEventIdAndFormatIdDocument
+  '\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllEventCategoriesFormEventDocument
+  '\n    query AllEventFormatsFormEvent {\n      allEventFormats {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllEventFormatsFormEventDocument
   '\n    mutation CreateGuests($createGuestsInput: CreateGuestsInput!) {\n      createGuests(input: $createGuestsInput) {\n        result {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.CreateGuestsDocument
   '\n    mutation AccountPasswordChange($input: AccountPasswordChangeInput!) {\n      accountPasswordChange(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountPasswordChangeDocument
   '\n    mutation AccountPasswordReset($input: AccountPasswordResetInput!) {\n      accountPasswordReset(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountPasswordResetDocument
@@ -66,7 +72,7 @@ type Documents = {
   '\n    mutation AttendanceCheckOut(\n      $id: UUID!\n      $attendancePatch: AttendancePatch!\n    ) {\n      updateAttendanceByRowId(\n        input: { rowId: $id, attendancePatch: $attendancePatch }\n      ) {\n        attendance {\n          id\n          checkedOut\n          rowId\n        }\n      }\n    }\n  ': typeof types.AttendanceCheckOutDocument
   '\n  query DashboardEventRecommendations($id: UUID!) {\n    eventByRowId(rowId: $id) {\n      accountByCreatedBy {\n        id\n        rowId\n        username\n      }\n      addressByAddressId {\n        id\n        location {\n          latitude\n          longitude\n        }\n        rowId\n      }\n      eventFavoritesByEventId(first: 1) {\n        nodes {\n          createdBy\n          id\n          rowId\n        }\n      }\n      guestsByEventId(first: 1) {\n        nodes {\n          contactByContactId {\n            accountId\n            id\n            rowId\n          }\n          id\n          rowId\n        }\n      }\n      id\n      name\n      rowId\n      slug\n      start\n    }\n  }\n': typeof types.DashboardEventRecommendationsDocument
   '\n  query DashboardEventUpcoming($createdBy: UUID!) {\n    allEvents(condition: { createdBy: $createdBy }) {\n      nodes {\n        accountByCreatedBy {\n          id\n          rowId\n          username\n        }\n        end\n        id\n        name\n        rowId\n        slug\n        start\n      }\n    }\n  }\n': typeof types.DashboardEventUpcomingDocument
-  '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ': typeof types.EventEditDocument
+  '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            eventCategoryMappingsByEventId {\n              nodes {\n                categoryId\n                id\n              }\n            }\n            eventFormatMappingsByEventId {\n              nodes {\n                formatId\n                id\n              }\n            }\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ': typeof types.EventEditDocument
   '\n    mutation EventDelete($input: EventDeleteInput!) {\n      eventDelete(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.EventDeleteDocument
   '\n    query EventAttendance($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            id\n            name\n            rowId\n            slug\n          }\n        }\n        id\n      }\n    }\n  ': typeof types.EventAttendanceDocument
   '\n    mutation AttendanceCreate($input: CreateAttendanceInput!) {\n      createAttendance(input: $input) {\n        attendance {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.AttendanceCreateDocument
@@ -87,7 +93,7 @@ type Documents = {
   '\n  mutation JwtUpdateGuestAdd($input: JwtUpdateGuestAddInput!) {\n    jwtUpdateGuestAdd(input: $input) {\n      result\n    }\n  }\n': typeof types.JwtUpdateGuestAddDocument
   '\n  mutation AccountRegistration($input: AccountRegistrationInput!) {\n    accountRegistration(input: $input) {\n      clientMutationId\n    }\n  }\n': typeof types.AccountRegistrationDocument
   '\n  fragment ContactItem on Contact {\n    accountId\n    accountByAccountId {\n      id\n      rowId\n      username\n    }\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    emailAddress\n    emailAddressHash\n    firstName\n    id\n    lastName\n    nickname\n    note\n    phoneNumber\n    rowId\n    url\n  }\n': typeof types.ContactItemFragmentDoc
-  '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n': typeof types.EventItemFragmentDoc
+  '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    eventCategoryMappingsByEventId {\n      nodes {\n        categoryId\n        id\n      }\n    }\n    eventFormatMappingsByEventId {\n      nodes {\n        formatId\n        id\n      }\n    }\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n': typeof types.EventItemFragmentDoc
   '\n  fragment GuestItem on Guest {\n    contactByContactId {\n      ...ContactItem\n    }\n    contactId\n    feedback\n    id\n    rowId\n  }\n': typeof types.GuestItemFragmentDoc
   '\n  fragment PreferenceEventCategoryItem on PreferenceEventCategory {\n    categoryId\n    id\n  }\n': typeof types.PreferenceEventCategoryItemFragmentDoc
   '\n  query AllPreferenceEventCategories {\n    allPreferenceEventCategories {\n      nodes {\n        ...PreferenceEventCategoryItem\n      }\n    }\n  }\n': typeof types.AllPreferenceEventCategoriesDocument
@@ -129,10 +135,22 @@ const documents: Documents = {
     types.CreateContactDocument,
   '\n    mutation UpdateContactByRowId($input: UpdateContactByRowIdInput!) {\n      updateContactByRowId(input: $input) {\n        contact {\n          ...ContactItem\n        }\n      }\n    }\n  ':
     types.UpdateContactByRowIdDocument,
-  '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ':
+  '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.CreateEventDocument,
   '\n    mutation updateEventByRowId($input: UpdateEventByRowIdInput!) {\n      updateEventByRowId(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ':
     types.UpdateEventByRowIdDocument,
+  '\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ':
+    types.CreateEventCategoryMappingDocument,
+  '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ':
+    types.DeleteEventCategoryMappingByEventIdAndCategoryIdDocument,
+  '\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ':
+    types.CreateEventFormatMappingDocument,
+  '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ':
+    types.DeleteEventFormatMappingByEventIdAndFormatIdDocument,
+  '\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ':
+    types.AllEventCategoriesFormEventDocument,
+  '\n    query AllEventFormatsFormEvent {\n      allEventFormats {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ':
+    types.AllEventFormatsFormEventDocument,
   '\n    mutation CreateGuests($createGuestsInput: CreateGuestsInput!) {\n      createGuests(input: $createGuestsInput) {\n        result {\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.CreateGuestsDocument,
   '\n    mutation AccountPasswordChange($input: AccountPasswordChangeInput!) {\n      accountPasswordChange(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
@@ -201,7 +219,7 @@ const documents: Documents = {
     types.DashboardEventRecommendationsDocument,
   '\n  query DashboardEventUpcoming($createdBy: UUID!) {\n    allEvents(condition: { createdBy: $createdBy }) {\n      nodes {\n        accountByCreatedBy {\n          id\n          rowId\n          username\n        }\n        end\n        id\n        name\n        rowId\n        slug\n        start\n      }\n    }\n  }\n':
     types.DashboardEventUpcomingDocument,
-  '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ':
+  '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            eventCategoryMappingsByEventId {\n              nodes {\n                categoryId\n                id\n              }\n            }\n            eventFormatMappingsByEventId {\n              nodes {\n                formatId\n                id\n              }\n            }\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ':
     types.EventEditDocument,
   '\n    mutation EventDelete($input: EventDeleteInput!) {\n      eventDelete(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.EventDeleteDocument,
@@ -243,7 +261,7 @@ const documents: Documents = {
     types.AccountRegistrationDocument,
   '\n  fragment ContactItem on Contact {\n    accountId\n    accountByAccountId {\n      id\n      rowId\n      username\n    }\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    emailAddress\n    emailAddressHash\n    firstName\n    id\n    lastName\n    nickname\n    note\n    phoneNumber\n    rowId\n    url\n  }\n':
     types.ContactItemFragmentDoc,
-  '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n':
+  '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    eventCategoryMappingsByEventId {\n      nodes {\n        categoryId\n        id\n      }\n    }\n    eventFormatMappingsByEventId {\n      nodes {\n        formatId\n        id\n      }\n    }\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n':
     types.EventItemFragmentDoc,
   '\n  fragment GuestItem on Guest {\n    contactByContactId {\n      ...ContactItem\n    }\n    contactId\n    feedback\n    id\n    rowId\n  }\n':
     types.GuestItemFragmentDoc,
@@ -375,14 +393,50 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ']
+  source: '\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n          rowId\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation CreateEvent($input: CreateEventInput!) {\n      createEvent(input: $input) {\n        event {\n          id\n          rowId\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
   source: '\n    mutation updateEventByRowId($input: UpdateEventByRowIdInput!) {\n      updateEventByRowId(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ',
 ): (typeof documents)['\n    mutation updateEventByRowId($input: UpdateEventByRowIdInput!) {\n      updateEventByRowId(input: $input) {\n        event {\n          id\n        }\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation CreateEventCategoryMapping(\n      $input: CreateEventCategoryMappingInput!\n    ) {\n      createEventCategoryMapping(input: $input) {\n        eventCategoryMapping {\n          categoryId\n          eventByEventId {\n            id\n          }\n          id\n        }\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteEventCategoryMappingByEventIdAndCategoryId(\n      $input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput!\n    ) {\n      deleteEventCategoryMappingByEventIdAndCategoryId(input: $input) {\n        deletedEventCategoryMappingId\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation CreateEventFormatMapping($input: CreateEventFormatMappingInput!) {\n      createEventFormatMapping(input: $input) {\n        eventFormatMapping {\n          eventByEventId {\n            id\n          }\n          formatId\n          id\n        }\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteEventFormatMappingByEventIdAndFormatId(\n      $input: DeleteEventFormatMappingByEventIdAndFormatIdInput!\n    ) {\n      deleteEventFormatMappingByEventIdAndFormatId(input: $input) {\n        deletedEventFormatMappingId\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    query AllEventCategoriesFormEvent {\n      allEventCategories {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    query AllEventFormatsFormEvent {\n      allEventFormats {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    query AllEventFormatsFormEvent {\n      allEventFormats {\n        nodes {\n          id\n          name\n          rowId\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -591,8 +645,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ',
-): (typeof documents)['\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ']
+  source: '\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            eventCategoryMappingsByEventId {\n              nodes {\n                categoryId\n                id\n              }\n            }\n            eventFormatMappingsByEventId {\n              nodes {\n                formatId\n                id\n              }\n            }\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ',
+): (typeof documents)['\n    query EventEdit($slug: String!, $username: String!) {\n      accountByUsername(username: $username) {\n        eventsByCreatedBy(condition: { slug: $slug }) {\n          nodes {\n            createdBy\n            description\n            end\n            eventCategoryMappingsByEventId {\n              nodes {\n                categoryId\n                id\n              }\n            }\n            eventFormatMappingsByEventId {\n              nodes {\n                formatId\n                id\n              }\n            }\n            id\n            guestCountMaximum\n            isArchived\n            isInPerson\n            isRemote\n            name\n            rowId\n            slug\n            start\n            url\n            visibility\n          }\n        }\n        id\n        rowId\n        username\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -717,8 +771,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n',
-): (typeof documents)['\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n']
+  source: '\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    eventCategoryMappingsByEventId {\n      nodes {\n        categoryId\n        id\n      }\n    }\n    eventFormatMappingsByEventId {\n      nodes {\n        formatId\n        id\n      }\n    }\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n',
+): (typeof documents)['\n  fragment EventItem on Event {\n    accountByCreatedBy {\n      id\n      rowId\n      username\n    }\n    createdBy\n    description\n    end\n    eventCategoryMappingsByEventId {\n      nodes {\n        categoryId\n        id\n      }\n    }\n    eventFormatMappingsByEventId {\n      nodes {\n        formatId\n        id\n      }\n    }\n    guestCountMaximum\n    id\n    isArchived\n    isInPerson\n    isRemote\n    name\n    rowId\n    slug\n    start\n    url\n    visibility\n  }\n']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -221,6 +221,17 @@ export type CreateDeviceInput = {
   device: DeviceInput
 }
 
+/** All input for the create `EventCategoryMapping` mutation. */
+export type CreateEventCategoryMappingInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: string | null | undefined
+  /** The `EventCategoryMapping` to be created by this mutation. */
+  eventCategoryMapping: EventCategoryMappingInput
+}
+
 /** All input for the create `EventFavorite` mutation. */
 export type CreateEventFavoriteInput = {
   /**
@@ -230,6 +241,17 @@ export type CreateEventFavoriteInput = {
   clientMutationId?: string | null | undefined
   /** The `EventFavorite` to be created by this mutation. */
   eventFavorite: EventFavoriteInput
+}
+
+/** All input for the create `EventFormatMapping` mutation. */
+export type CreateEventFormatMappingInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: string | null | undefined
+  /** The `EventFormatMapping` to be created by this mutation. */
+  eventFormatMapping: EventFormatMappingInput
 }
 
 /** All input for the create `Event` mutation. */
@@ -368,6 +390,19 @@ export type DeleteDeviceByCreatedByAndFcmTokenInput = {
   fcmToken: string
 }
 
+/** All input for the `deleteEventCategoryMappingByEventIdAndCategoryId` mutation. */
+export type DeleteEventCategoryMappingByEventIdAndCategoryIdInput = {
+  /** A category id. */
+  categoryId: string
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: string | null | undefined
+  /** An event id. */
+  eventId: string
+}
+
 /** All input for the `deleteEventFavoriteByRowId` mutation. */
 export type DeleteEventFavoriteByRowIdInput = {
   /**
@@ -377,6 +412,19 @@ export type DeleteEventFavoriteByRowIdInput = {
   clientMutationId?: string | null | undefined
   /** Primary key, uniquely identifies each favorite entry. */
   rowId: string
+}
+
+/** All input for the `deleteEventFormatMappingByEventIdAndFormatId` mutation. */
+export type DeleteEventFormatMappingByEventIdAndFormatIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: string | null | undefined
+  /** An event id. */
+  eventId: string
+  /** A format id. */
+  formatId: string
 }
 
 /** All input for the `deleteGuestByRowId` mutation. */
@@ -470,6 +518,14 @@ export type DeviceInput = {
   fcmToken: string
 }
 
+/** An input for mutations affecting `EventCategoryMapping` */
+export type EventCategoryMappingInput = {
+  /** A category id. */
+  categoryId: string
+  /** An event id. */
+  eventId: string
+}
+
 /** All input for the `eventDelete` mutation. */
 export type EventDeleteInput = {
   /**
@@ -487,6 +543,14 @@ export type EventFavoriteInput = {
   createdBy: string
   /** Reference to the event that is marked as a favorite. */
   eventId: string
+}
+
+/** An input for mutations affecting `EventFormatMapping` */
+export type EventFormatMappingInput = {
+  /** An event id. */
+  eventId: string
+  /** A format id. */
+  formatId: string
 }
 
 /** An input for mutations affecting `Event` */
@@ -1012,7 +1076,7 @@ export type CreateEventMutationVariables = Exact<{
 }>
 
 export type CreateEventMutation = {
-  createEvent: { event: { id: string } | null } | null
+  createEvent: { event: { id: string; rowId: string } | null } | null
 }
 
 export type UpdateEventByRowIdMutationVariables = Exact<{
@@ -1021,6 +1085,76 @@ export type UpdateEventByRowIdMutationVariables = Exact<{
 
 export type UpdateEventByRowIdMutation = {
   updateEventByRowId: { event: { id: string } | null } | null
+}
+
+export type CreateEventCategoryMappingMutationVariables = Exact<{
+  input: CreateEventCategoryMappingInput
+}>
+
+export type CreateEventCategoryMappingMutation = {
+  createEventCategoryMapping: {
+    eventCategoryMapping: {
+      categoryId: string
+      id: string
+      eventByEventId: { id: string } | null
+    } | null
+  } | null
+}
+
+export type DeleteEventCategoryMappingByEventIdAndCategoryIdMutationVariables =
+  Exact<{
+    input: DeleteEventCategoryMappingByEventIdAndCategoryIdInput
+  }>
+
+export type DeleteEventCategoryMappingByEventIdAndCategoryIdMutation = {
+  deleteEventCategoryMappingByEventIdAndCategoryId: {
+    deletedEventCategoryMappingId: string | null
+  } | null
+}
+
+export type CreateEventFormatMappingMutationVariables = Exact<{
+  input: CreateEventFormatMappingInput
+}>
+
+export type CreateEventFormatMappingMutation = {
+  createEventFormatMapping: {
+    eventFormatMapping: {
+      formatId: string
+      id: string
+      eventByEventId: { id: string } | null
+    } | null
+  } | null
+}
+
+export type DeleteEventFormatMappingByEventIdAndFormatIdMutationVariables =
+  Exact<{
+    input: DeleteEventFormatMappingByEventIdAndFormatIdInput
+  }>
+
+export type DeleteEventFormatMappingByEventIdAndFormatIdMutation = {
+  deleteEventFormatMappingByEventIdAndFormatId: {
+    deletedEventFormatMappingId: string | null
+  } | null
+}
+
+export type AllEventCategoriesFormEventQueryVariables = Exact<{
+  [key: string]: never
+}>
+
+export type AllEventCategoriesFormEventQuery = {
+  allEventCategories: {
+    nodes: Array<{ id: string; name: string; rowId: string }>
+  } | null
+}
+
+export type AllEventFormatsFormEventQueryVariables = Exact<{
+  [key: string]: never
+}>
+
+export type AllEventFormatsFormEventQuery = {
+  allEventFormats: {
+    nodes: Array<{ id: string; name: string; rowId: string }>
+  } | null
 }
 
 export type CreateGuestsMutationVariables = Exact<{
@@ -1525,6 +1659,12 @@ export type EventEditQuery = {
         start: string
         url: string | null
         visibility: EventVisibility
+        eventCategoryMappingsByEventId: {
+          nodes: Array<{ categoryId: string; id: string }>
+        }
+        eventFormatMappingsByEventId: {
+          nodes: Array<{ formatId: string; id: string }>
+        }
       }>
     }
   } | null
@@ -1858,6 +1998,12 @@ export type EventItemFragment = {
   url: string | null
   visibility: EventVisibility
   accountByCreatedBy: { id: string; rowId: string; username: string } | null
+  eventCategoryMappingsByEventId: {
+    nodes: Array<{ categoryId: string; id: string }>
+  }
+  eventFormatMappingsByEventId: {
+    nodes: Array<{ formatId: string; id: string }>
+  }
 } & { ' $fragmentName'?: 'EventItemFragment' }
 
 export type GuestItemFragment = {
@@ -1957,6 +2103,52 @@ export const EventItemFragmentDoc = {
           { kind: 'Field', name: { kind: 'Name', value: 'createdBy' } },
           { kind: 'Field', name: { kind: 'Name', value: 'description' } },
           { kind: 'Field', name: { kind: 'Name', value: 'end' } },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'eventCategoryMappingsByEventId' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'categoryId' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'eventFormatMappingsByEventId' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'formatId' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
           { kind: 'Field', name: { kind: 'Name', value: 'guestCountMaximum' } },
           { kind: 'Field', name: { kind: 'Name', value: 'id' } },
           { kind: 'Field', name: { kind: 'Name', value: 'isArchived' } },
@@ -3948,6 +4140,7 @@ export const CreateEventDocument = {
                     kind: 'SelectionSet',
                     selections: [
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'rowId' } },
                     ],
                   },
                 },
@@ -4021,6 +4214,379 @@ export const UpdateEventByRowIdDocument = {
 } as unknown as DocumentNode<
   UpdateEventByRowIdMutation,
   UpdateEventByRowIdMutationVariables
+>
+export const CreateEventCategoryMappingDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'CreateEventCategoryMapping' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'CreateEventCategoryMappingInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'createEventCategoryMapping' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'eventCategoryMapping' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'categoryId' },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'eventByEventId' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateEventCategoryMappingMutation,
+  CreateEventCategoryMappingMutationVariables
+>
+export const DeleteEventCategoryMappingByEventIdAndCategoryIdDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {
+        kind: 'Name',
+        value: 'DeleteEventCategoryMappingByEventIdAndCategoryId',
+      },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'DeleteEventCategoryMappingByEventIdAndCategoryIdInput',
+              },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {
+              kind: 'Name',
+              value: 'deleteEventCategoryMappingByEventIdAndCategoryId',
+            },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {
+                    kind: 'Name',
+                    value: 'deletedEventCategoryMappingId',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteEventCategoryMappingByEventIdAndCategoryIdMutation,
+  DeleteEventCategoryMappingByEventIdAndCategoryIdMutationVariables
+>
+export const CreateEventFormatMappingDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'CreateEventFormatMapping' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'CreateEventFormatMappingInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'createEventFormatMapping' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'eventFormatMapping' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'eventByEventId' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'formatId' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateEventFormatMappingMutation,
+  CreateEventFormatMappingMutationVariables
+>
+export const DeleteEventFormatMappingByEventIdAndFormatIdDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: {
+        kind: 'Name',
+        value: 'DeleteEventFormatMappingByEventIdAndFormatId',
+      },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: {
+                kind: 'Name',
+                value: 'DeleteEventFormatMappingByEventIdAndFormatIdInput',
+              },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {
+              kind: 'Name',
+              value: 'deleteEventFormatMappingByEventIdAndFormatId',
+            },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'deletedEventFormatMappingId' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteEventFormatMappingByEventIdAndFormatIdMutation,
+  DeleteEventFormatMappingByEventIdAndFormatIdMutationVariables
+>
+export const AllEventCategoriesFormEventDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AllEventCategoriesFormEvent' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'allEventCategories' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'rowId' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  AllEventCategoriesFormEventQuery,
+  AllEventCategoriesFormEventQueryVariables
+>
+export const AllEventFormatsFormEventDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: { kind: 'Name', value: 'AllEventFormatsFormEvent' },
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'allEventFormats' },
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'nodes' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'name' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'rowId' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  AllEventFormatsFormEventQuery,
+  AllEventFormatsFormEventQueryVariables
 >
 export const CreateGuestsDocument = {
   kind: 'Document',
@@ -6994,6 +7560,70 @@ export const EventEditDocument = {
                             {
                               kind: 'Field',
                               name: { kind: 'Name', value: 'end' },
+                            },
+                            {
+                              kind: 'Field',
+                              name: {
+                                kind: 'Name',
+                                value: 'eventCategoryMappingsByEventId',
+                              },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'nodes' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'categoryId',
+                                          },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'id' },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: 'Field',
+                              name: {
+                                kind: 'Name',
+                                value: 'eventFormatMappingsByEventId',
+                              },
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {
+                                    kind: 'Field',
+                                    name: { kind: 'Name', value: 'nodes' },
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {
+                                          kind: 'Field',
+                                          name: {
+                                            kind: 'Name',
+                                            value: 'formatId',
+                                          },
+                                        },
+                                        {
+                                          kind: 'Field',
+                                          name: { kind: 'Name', value: 'id' },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
                             },
                             {
                               kind: 'Field',

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1109,6 +1109,7 @@ export type DeleteEventCategoryMappingByEventIdAndCategoryIdMutationVariables =
 export type DeleteEventCategoryMappingByEventIdAndCategoryIdMutation = {
   deleteEventCategoryMappingByEventIdAndCategoryId: {
     deletedEventCategoryMappingId: string | null
+    eventCategoryMapping: { eventByEventId: { id: string } | null } | null
   } | null
 }
 
@@ -1134,6 +1135,7 @@ export type DeleteEventFormatMappingByEventIdAndFormatIdMutationVariables =
 export type DeleteEventFormatMappingByEventIdAndFormatIdMutation = {
   deleteEventFormatMappingByEventIdAndFormatId: {
     deletedEventFormatMappingId: string | null
+    eventFormatMapping: { eventByEventId: { id: string } | null } | null
   } | null
 }
 
@@ -4353,6 +4355,28 @@ export const DeleteEventCategoryMappingByEventIdAndCategoryIdDocument = {
                     value: 'deletedEventCategoryMappingId',
                   },
                 },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'eventCategoryMapping' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'eventByEventId' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
               ],
             },
           },
@@ -4498,6 +4522,28 @@ export const DeleteEventFormatMappingByEventIdAndFormatIdDocument = {
                 {
                   kind: 'Field',
                   name: { kind: 'Name', value: 'deletedEventFormatMappingId' },
+                },
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'eventFormatMapping' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'eventByEventId' },
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: { kind: 'Name', value: 'id' },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
                 },
               ],
             },

--- a/src/shared/utils/event.ts
+++ b/src/shared/utils/event.ts
@@ -13,6 +13,18 @@ export const EventItem = graphql(`
     createdBy
     description
     end
+    eventCategoryMappingsByEventId {
+      nodes {
+        categoryId
+        id
+      }
+    }
+    eventFormatMappingsByEventId {
+      nodes {
+        formatId
+        id
+      }
+    }
     guestCountMaximum
     id
     isArchived

--- a/src/shared/utils/urql.ts
+++ b/src/shared/utils/urql.ts
@@ -196,6 +196,28 @@ export const getUrqlClient = async ({
             { first: 1 },
           )
         },
+        createEventCategoryMapping: (result, _args, cache, _info) => {
+          const eventId =
+            result.createEventCategoryMapping?.eventCategoryMapping
+              ?.eventByEventId?.id
+          if (!eventId) return
+
+          cache.invalidate(
+            { __typename: 'Event', id: eventId },
+            'eventCategoryMappingsByEventId',
+          )
+        },
+        createEventFormatMapping: (result, _args, cache, _info) => {
+          const eventId =
+            result.createEventFormatMapping?.eventFormatMapping?.eventByEventId
+              ?.id
+          if (!eventId) return
+
+          cache.invalidate(
+            { __typename: 'Event', id: eventId },
+            'eventFormatMappingsByEventId',
+          )
+        },
         createPreferenceEventCategory: (result, _args, cache, _info) =>
           cacheListAppend({
             cache,
@@ -235,6 +257,36 @@ export const getUrqlClient = async ({
           invalidateCache(cache, 'Guest', args),
         deleteEventFavoriteByRowId: (_result, args, cache, _info) =>
           invalidateCache(cache, 'EventFavorite', args),
+        deleteEventCategoryMappingByEventIdAndCategoryId: (
+          result,
+          _args,
+          cache,
+          _info,
+        ) => {
+          const deletedId =
+            result.deleteEventCategoryMappingByEventIdAndCategoryId
+              ?.deletedEventCategoryMappingId
+          if (deletedId)
+            cache.invalidate({
+              __typename: 'EventCategoryMapping',
+              id: deletedId,
+            })
+        },
+        deleteEventFormatMappingByEventIdAndFormatId: (
+          result,
+          _args,
+          cache,
+          _info,
+        ) => {
+          const deletedId =
+            result.deleteEventFormatMappingByEventIdAndFormatId
+              ?.deletedEventFormatMappingId
+          if (deletedId)
+            cache.invalidate({
+              __typename: 'EventFormatMapping',
+              id: deletedId,
+            })
+        },
         deletePreferenceEventCategoryByAccountIdAndCategoryId: (
           result,
           _args,

--- a/src/shared/utils/urql.ts
+++ b/src/shared/utils/urql.ts
@@ -263,14 +263,22 @@ export const getUrqlClient = async ({
           cache,
           _info,
         ) => {
-          const deletedId =
+          const payload =
             result.deleteEventCategoryMappingByEventIdAndCategoryId
-              ?.deletedEventCategoryMappingId
-          if (deletedId)
+          if (!payload) return
+
+          if (payload.deletedEventCategoryMappingId)
             cache.invalidate({
               __typename: 'EventCategoryMapping',
-              id: deletedId,
+              id: payload.deletedEventCategoryMappingId,
             })
+
+          const eventId = payload.eventCategoryMapping?.eventByEventId?.id
+          if (eventId)
+            cache.invalidate(
+              { __typename: 'Event', id: eventId },
+              'eventCategoryMappingsByEventId',
+            )
         },
         deleteEventFormatMappingByEventIdAndFormatId: (
           result,
@@ -278,14 +286,21 @@ export const getUrqlClient = async ({
           cache,
           _info,
         ) => {
-          const deletedId =
-            result.deleteEventFormatMappingByEventIdAndFormatId
-              ?.deletedEventFormatMappingId
-          if (deletedId)
+          const payload = result.deleteEventFormatMappingByEventIdAndFormatId
+          if (!payload) return
+
+          if (payload.deletedEventFormatMappingId)
             cache.invalidate({
               __typename: 'EventFormatMapping',
-              id: deletedId,
+              id: payload.deletedEventFormatMappingId,
             })
+
+          const eventId = payload.eventFormatMapping?.eventByEventId?.id
+          if (eventId)
+            cache.invalidate(
+              { __typename: 'Event', id: eventId },
+              'eventFormatMappingsByEventId',
+            )
         },
         deletePreferenceEventCategoryByAccountIdAndCategoryId: (
           result,


### PR DESCRIPTION
Adds category and format selection to the event create/edit form. The PostGraphile schema already supported many-to-many event categories/formats via junction-table mutations (`createEventCategoryMapping`/`createEventFormatMapping` and their delete equivalents); this wires the existing `EventCategory`/`EventFormat` lookups and icon set (already used for onboarding preferences) into `FormEvent.vue`, syncing selections on submit for both create and edit.