### PR TITLE
fix(event): correct date picker disabled by empty start/end value

### DIFF
--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -242,7 +242,7 @@
           :is24hr="locale !== 'en'"
           :locale
           :masks="{ input: 'YYYY-MM-DD h:mm A' }"
-          :max-date="form.getFieldValue('end')"
+          :max-date="form.getFieldValue('end') || undefined"
           :minute-increment="5"
           mode="dateTime"
           :model-value="form.getFieldValue('start')"
@@ -258,7 +258,7 @@
           :is24hr="locale !== 'en'"
           :locale
           :masks="{ input: 'YYYY-MM-DD h:mm A' }"
-          :min-date="form.getFieldValue('start')"
+          :min-date="form.getFieldValue('start') || undefined"
           :minute-increment="5"
           mode="dateTime"
           :model-value="form.getFieldValue('end')"

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -245,8 +245,17 @@
           :max-date="form.getFieldValue('end') || undefined"
           :minute-increment="5"
           mode="dateTime"
-          :model-value="form.getFieldValue('start')"
-          @update:model-value="form.setFieldValue('start', $event as string)"
+          :model-value="
+            form.getFieldValue('start')
+              ? new Date(form.getFieldValue('start'))
+              : null
+          "
+          @update:model-value="
+            form.setFieldValue(
+              'start',
+              ($event as Date | null)?.toISOString() ?? '',
+            )
+          "
         />
       </div>
     </Modal>
@@ -261,8 +270,17 @@
           :min-date="form.getFieldValue('start') || undefined"
           :minute-increment="5"
           mode="dateTime"
-          :model-value="form.getFieldValue('end')"
-          @update:model-value="form.setFieldValue('end', $event as string)"
+          :model-value="
+            form.getFieldValue('end')
+              ? new Date(form.getFieldValue('end'))
+              : null
+          "
+          @update:model-value="
+            form.setFieldValue(
+              'end',
+              ($event as Date | null)?.toISOString() ?? '',
+            )
+          "
         />
       </div>
     </Modal>


### PR DESCRIPTION
The date picker for the event's start date disabled every day when the end date field was empty, since `v-calendar` treated the empty string as an invalid `max-date` bound. The same issue affected the end date picker's `min-date` bound. Both bounds now fall back to `undefined` when the counterpart field is unset.