### PR TITLE
feat(button): add and wire up loading indicator

### DIFF
--- a/src/app/components/account/block/AccountBlockDrawer.vue
+++ b/src/app/components/account/block/AccountBlockDrawer.vue
@@ -47,6 +47,7 @@
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('confirmBlock')"
+          :loading="createAccountBlockMutation.fetching.value"
           variant="primary-critical"
           @click="blockUser"
         >
@@ -133,7 +134,7 @@ const createAccountBlockMutation = useMutation(
     }
   `),
 )
-// const api = await useApiData([createAccountBlockMutation]) // TODO: show loading state, error details
+// TODO: show error details
 const blockUser = async () => {
   const result = await createAccountBlockMutation.executeMutation({
     input: {

--- a/src/app/components/account/block/AccountBlockRemoveDrawer.vue
+++ b/src/app/components/account/block/AccountBlockRemoveDrawer.vue
@@ -57,6 +57,7 @@
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('unblock')"
+          :loading="deleteAccountBlockMutation.fetching.value"
           @click="unblockUser"
         >
           {{ t('unblock') }}

--- a/src/app/components/app/AppLink.vue
+++ b/src/app/components/app/AppLink.vue
@@ -6,7 +6,7 @@
     :external="isExternal"
     :target="targetComputed"
     :to
-    @click="emit('click')"
+    @click="emit('click', $event)"
   >
     <slot />
   </NuxtLink>
@@ -41,7 +41,7 @@ const {
 >()
 
 const emit = defineEmits<{
-  click: []
+  click: [event: MouseEvent]
 }>()
 
 // computations

--- a/src/app/components/app/button/AppButton.vue
+++ b/src/app/components/app/button/AppButton.vue
@@ -5,30 +5,43 @@
     :aria-label
     :class="cn(classComputed, classProps)"
     :is-colored="false"
-    :is-disabled="disabled"
+    :is-disabled="disabled || loading"
     :to
     @click="emit('click')"
   >
-    <slot name="prefix" />
-    <!-- <div class="truncate-overflow"> -->
-    <slot />
-    <!-- </div> -->
-    <slot name="suffix" />
+    <template v-if="loading">
+      <AppButtonSpinner />
+      <slot name="loading">{{ t('globalLoading') }}</slot>
+    </template>
+    <template v-else>
+      <slot name="prefix" />
+      <!-- <div class="truncate-overflow"> -->
+      <slot />
+      <!-- </div> -->
+      <slot name="suffix" />
+    </template>
   </AppLink>
   <button
     v-else
+    :aria-busy="loading"
     :aria-label
     :class="cn(['rounded-sm', classComputed], classProps)"
-    :disabled
+    :disabled="disabled || loading"
     :title="ariaLabel"
     :type
     @click="emit('click')"
   >
-    <slot name="prefix" />
-    <!-- <span class="truncate-overflow"> -->
-    <slot />
-    <!-- </span> -->
-    <slot name="suffix" />
+    <template v-if="loading">
+      <AppButtonSpinner />
+      <slot name="loading">{{ t('globalLoading') }}</slot>
+    </template>
+    <template v-else>
+      <slot name="prefix" />
+      <!-- <span class="truncate-overflow"> -->
+      <slot />
+      <!-- </span> -->
+      <slot name="suffix" />
+    </template>
   </button>
 </template>
 
@@ -45,6 +58,7 @@ const {
   isBlock,
   isExternal,
   isLinkColored,
+  loading,
   to = undefined,
   type = 'button',
 } = defineProps<
@@ -54,6 +68,7 @@ const {
     isBlock?: boolean
     isExternal?: boolean
     isLinkColored?: boolean
+    loading?: boolean
     to?: RouteLocationRaw
     type?: ButtonHTMLAttributes['type']
   } & { class?: HtmlHTMLAttributes['class'] }
@@ -66,6 +81,8 @@ const delegatedProps = computed(() => ({
 const emit = defineEmits<{
   click: []
 }>()
+
+const { t } = useI18n()
 
 // computations
 const classComputed = computed(() =>

--- a/src/app/components/app/button/AppButton.vue
+++ b/src/app/components/app/button/AppButton.vue
@@ -2,6 +2,7 @@
   <AppLink
     v-if="to"
     v-bind="delegatedProps"
+    :aria-busy="loading"
     :aria-label
     :class="cn(classComputed, classProps)"
     :is-colored="false"
@@ -14,7 +15,7 @@
           event.stopPropagation()
           return
         }
-        emit('click')
+        emit('click', event)
       }
     "
   >
@@ -38,7 +39,7 @@
     :disabled="disabled || loading"
     :title="ariaLabel"
     :type
-    @click="emit('click')"
+    @click="emit('click', $event)"
   >
     <template v-if="loading">
       <AppButtonSpinner />
@@ -88,7 +89,7 @@ const delegatedProps = computed(() => ({
 }))
 
 const emit = defineEmits<{
-  click: []
+  click: [event: MouseEvent]
 }>()
 
 const { t } = useI18n()

--- a/src/app/components/app/button/AppButton.vue
+++ b/src/app/components/app/button/AppButton.vue
@@ -7,7 +7,16 @@
     :is-colored="false"
     :is-disabled="disabled || loading"
     :to
-    @click="emit('click')"
+    @click="
+      (event: MouseEvent) => {
+        if (disabled || loading) {
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        emit('click')
+      }
+    "
   >
     <template v-if="loading">
       <AppButtonSpinner />

--- a/src/app/components/app/button/AppButtonSpinner.vue
+++ b/src/app/components/app/button/AppButtonSpinner.vue
@@ -1,0 +1,23 @@
+<template>
+  <svg
+    aria-hidden="true"
+    class="size-4 shrink-0 animate-spin"
+    fill="none"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle
+      class="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      stroke-width="4"
+    />
+    <path
+      class="opacity-75"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      fill="currentColor"
+    />
+  </svg>
+</template>

--- a/src/app/components/app/input/AppInputTextarea.vue
+++ b/src/app/components/app/input/AppInputTextarea.vue
@@ -107,9 +107,17 @@ const cancel = () => {
   isEditing.value = false
 }
 const isSaving = ref(false)
-const save = () => {
+const save = async () => {
   isSaving.value = true
   emit('save', content.value?.trim())
+
+  // the caller may not actually start a loading request (e.g. a guard
+  // clause returning early), in which case there is no loading
+  // transition to reset `isSaving` below
+  await nextTick()
+  if (!loading) {
+    isSaving.value = false
+  }
 }
 
 // closes editing once this instance's save request settles

--- a/src/app/components/app/input/AppInputTextarea.vue
+++ b/src/app/components/app/input/AppInputTextarea.vue
@@ -106,16 +106,19 @@ const cancel = () => {
   content.value = contentInitial?.trim()
   isEditing.value = false
 }
+const isSaving = ref(false)
 const save = () => {
+  isSaving.value = true
   emit('save', content.value?.trim())
 }
 
-// closes editing once the caller's save request settles
+// closes editing once this instance's save request settles
 watch(
   () => loading,
   (loadingCurrent, loadingPrevious) => {
-    if (loadingPrevious && !loadingCurrent) {
+    if (loadingPrevious && !loadingCurrent && isSaving.value) {
       isEditing.value = false
+      isSaving.value = false
     }
   },
 )

--- a/src/app/components/app/input/AppInputTextarea.vue
+++ b/src/app/components/app/input/AppInputTextarea.vue
@@ -64,6 +64,7 @@
       <div v-if="isEditing" class="flex flex-col items-end gap-2 text-right">
         <ButtonColored
           :aria-label="t('saveChanges')"
+          :loading
           variant="secondary"
           @click="save"
         >
@@ -81,10 +82,12 @@
 const {
   contentInitial = undefined,
   lengthMaximum: maxLength,
+  loading,
   title,
 } = defineProps<{
   contentInitial?: string | null
   lengthMaximum: number
+  loading?: boolean
   title: string
 }>()
 
@@ -105,8 +108,17 @@ const cancel = () => {
 }
 const save = () => {
   emit('save', content.value?.trim())
-  isEditing.value = false
 }
+
+// closes editing once the caller's save request settles
+watch(
+  () => loading,
+  (loadingCurrent, loadingPrevious) => {
+    if (loadingPrevious && !loadingCurrent) {
+      isEditing.value = false
+    }
+  },
+)
 
 // template
 const { t } = useI18n()

--- a/src/app/components/button/ButtonColored.vue
+++ b/src/app/components/button/ButtonColored.vue
@@ -26,6 +26,9 @@
     <template #suffix>
       <slot name="suffix" />
     </template>
+    <template v-if="$slots.loading" #loading>
+      <slot name="loading" />
+    </template>
   </AppButton>
 </template>
 
@@ -39,6 +42,7 @@ export type ButtonColoredProps = {
   ariaLabel: string
   disabled?: boolean
   isExternal?: boolean
+  loading?: boolean
   size?: 'large' | 'small'
   to?: RouteLocationRaw
   type?: ButtonHTMLAttributes['type']
@@ -55,6 +59,7 @@ const {
   class: classProps = undefined,
   disabled,
   isExternal,
+  loading,
   size = 'large',
   to = undefined,
   type = 'button',
@@ -69,6 +74,7 @@ const delegatedProps = computed(() => ({
   ariaLabel,
   disabled,
   isExternal,
+  loading,
   to,
   type,
 }))

--- a/src/app/components/event/report/EventReportDrawer.vue
+++ b/src/app/components/event/report/EventReportDrawer.vue
@@ -62,6 +62,7 @@
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('buttonReportSubmit')"
+          :loading="templateForm?.isSubmitting"
           type="submit"
           variant="primary-critical"
           @click="templateForm?.submit"
@@ -81,6 +82,7 @@
         <ButtonColored
           v-bind="attributes"
           :aria-label="t('buttonReportConfirmationBlock')"
+          :loading="createAccountBlockMutation.fetching.value"
           variant="secondary-critical"
           @click="blockOrganizer"
         >

--- a/src/app/components/event/report/EventReportForm.vue
+++ b/src/app/components/event/report/EventReportForm.vue
@@ -78,7 +78,7 @@ const createReportMutation = useMutation(
 )
 
 defineExpose({
-  isSubmitting: createReportMutation.fetching,
+  isSubmitting: computed(() => createReportMutation.fetching.value),
   submit,
 })
 

--- a/src/app/components/event/report/EventReportForm.vue
+++ b/src/app/components/event/report/EventReportForm.vue
@@ -61,9 +61,6 @@ const formRef = useTemplateRef<HTMLFormElement>('formRef')
 
 // form
 const submit = () => formRef.value?.requestSubmit()
-defineExpose({
-  submit,
-})
 
 const formSchema = z.object({
   reason: z.string().min(1).max(2000),
@@ -79,6 +76,11 @@ const createReportMutation = useMutation(
     }
   `),
 )
+
+defineExpose({
+  isSubmitting: createReportMutation.fetching,
+  submit,
+})
 
 const form = useForm({
   defaultValues: {

--- a/src/app/components/form/FormContact.vue
+++ b/src/app/components/form/FormContact.vue
@@ -233,7 +233,12 @@
         </Field>
       </form.Field>
       <div class="flex flex-col items-center">
-        <ButtonColored :aria-label="t('save')" class="w-full" type="submit">
+        <ButtonColored
+          :aria-label="t('save')"
+          class="w-full"
+          :loading="api.isFetching"
+          type="submit"
+        >
           {{ t('save') }}
         </ButtonColored>
       </div>

--- a/src/app/components/form/FormDelete.vue
+++ b/src/app/components/form/FormDelete.vue
@@ -25,6 +25,7 @@
         <ButtonColored
           :aria-label="t('deletion', { item: itemNameDeletion })"
           class="w-full"
+          :loading="api.isFetching"
           type="submit"
           variant="primary-critical"
         >

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -222,6 +222,7 @@
               form.getFieldValue('rowId') ? t('eventUpdate') : t('eventCreate')
             "
             class="w-full"
+            :loading="api.isFetching"
             type="submit"
           >
             {{

--- a/src/app/components/form/FormGuest.vue
+++ b/src/app/components/form/FormGuest.vue
@@ -75,7 +75,12 @@
         </AppScrollContainer>
       </form.Field>
       <div class="flex flex-col items-center">
-        <ButtonColored :aria-label="t('select')" class="w-full" type="submit">
+        <ButtonColored
+          :aria-label="t('select')"
+          class="w-full"
+          :loading="createGuestsMutation.fetching.value"
+          type="submit"
+        >
           {{ t('select') }}
         </ButtonColored>
       </div>

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -43,7 +43,8 @@
         <slot name="footer">
           <ButtonColored
             :aria-label="submitName || t('ok')"
-            :disabled="isSubmitting || isSubmitDisabled"
+            :disabled="isSubmitDisabled"
+            :loading="isSubmitting"
             type="submit"
             @click="submit()"
           >

--- a/src/app/pages/account/edit/[username].vue
+++ b/src/app/pages/account/edit/[username].vue
@@ -45,6 +45,7 @@
           </ButtonColored>
           <ButtonColored
             :aria-label="t('remove')"
+            :loading="deleteProfilePictureByRowIdMutation.fetching.value"
             variant="secondary"
             @click="removeProfilePicture"
           >
@@ -60,12 +61,14 @@
       <AppInputTextarea
         :content-initial="account.description"
         :length-maximum="descriptionLengthMaximum"
+        :loading="updateAccountByRowIdMutation.fetching.value"
         :title="t('about')"
         @save="saveDescription"
       />
       <AppInputTextarea
         :content-initial="account.imprintUrl"
         :length-maximum="imprintLengthMaximum"
+        :loading="updateAccountByRowIdMutation.fetching.value"
         :title="t('imprint')"
         @save="saveImprint"
       />

--- a/src/app/pages/attendance/view/[id]/index.vue
+++ b/src/app/pages/attendance/view/[id]/index.vue
@@ -72,6 +72,7 @@
         <ButtonColored
           :aria-label="t('checkOut')"
           :disabled="!canCheckOut"
+          :loading="checkOutMutation.fetching.value"
           @click="onCheckOut"
         >
           {{ t('checkOut') }}

--- a/src/app/pages/event/ingest/image.vue
+++ b/src/app/pages/event/ingest/image.vue
@@ -52,7 +52,11 @@
             {{ t('clearAll') }}
           </ButtonColored>
         </div>
-        <ButtonColored :aria-label="t('uploadImage')" @click="uploadFile">
+        <ButtonColored
+          :aria-label="t('uploadImage')"
+          :loading="isUploading"
+          @click="uploadFile"
+        >
           {{ t('uploadImage') }}
         </ButtonColored>
       </div>
@@ -73,6 +77,7 @@ const alertError = useAlertError()
 const templateFileInput = useTemplateRef('fileInput')
 
 // data
+const isUploading = ref(false)
 const previewUrl = ref<string>()
 const selectedFile = ref<File>()
 
@@ -119,6 +124,7 @@ const uploadFile = async () => {
 
   const reader = new FileReader()
   reader.readAsDataURL(selectedFile.value)
+  isUploading.value = true
   reader.onload = async () => {
     const base64Image = (reader.result as string).split(',')[1]
 
@@ -133,10 +139,13 @@ const uploadFile = async () => {
         ...(error instanceof Error ? { error } : {}),
         messageI18n: t('uploadFailed'),
       })
+    } finally {
+      isUploading.value = false
     }
   }
   reader.onerror = () => {
     console.error('Error reading file')
+    isUploading.value = false
   }
 }
 </script>

--- a/src/app/pages/event/ingest/url.vue
+++ b/src/app/pages/event/ingest/url.vue
@@ -18,6 +18,7 @@
     <ButtonColored
       :aria-label="t('process')"
       class="self-end"
+      :loading="isUploading"
       @click="uploadURL"
     >
       {{ t('process') }}
@@ -33,9 +34,12 @@ definePageMeta({
 const { t } = useI18n()
 
 const enteredURL = ref<string>()
+const isUploading = ref(false)
 
 const uploadURL = async () => {
   if (!enteredURL.value) return
+
+  isUploading.value = true
 
   try {
     await $fetch('/api/model/event/ingest/url', {
@@ -44,6 +48,8 @@ const uploadURL = async () => {
     })
   } catch (error) {
     console.error('Upload failed:', error)
+  } finally {
+    isUploading.value = false
   }
 }
 </script>

--- a/src/app/pages/guest/view/[id]/index.vue
+++ b/src/app/pages/guest/view/[id]/index.vue
@@ -157,7 +157,7 @@
                     name: contactName,
                   })
             "
-            :disabled="isUpdatingAccept"
+            :loading="isUpdatingAccept"
             @click="accept"
           >
             <span>
@@ -170,8 +170,7 @@
               }}
             </span>
             <template #prefix>
-              <LoaderIndicatorSpinner v-if="isUpdatingAccept" class="size-8" />
-              <AppIconCheckCircleSolid v-else class="shrink-0" />
+              <AppIconCheckCircleSolid class="shrink-0" />
             </template>
           </ButtonColored>
           <div
@@ -204,7 +203,7 @@
                     name: contactName,
                   })
             "
-            :disabled="isUpdatingCancel"
+            :loading="isUpdatingCancel"
             @click="cancel"
           >
             <span>
@@ -217,8 +216,7 @@
               }}
             </span>
             <template #prefix>
-              <LoaderIndicatorSpinner v-if="isUpdatingCancel" class="size-8" />
-              <AppIconXCircleSolid v-else class="shrink-0" />
+              <AppIconXCircleSolid class="shrink-0" />
             </template>
           </ButtonColored>
           <div


### PR DESCRIPTION
Adds a `loading` prop to `AppButton` (spinner + text swapped in for the button's content, disabling interaction) and forwards it through `ButtonColored`. Wires it into the buttons behind real async work: shared `Modal` submit, `FormDelete`/`FormContact`/`FormEvent`/`FormGuest` submits, account block/unblock, event report/block, guest accept/decline, profile picture removal, account description/imprint save, attendance check-out, and the event-ingest upload pages.

Icon-only buttons (guest send, contact edit/delete, upload delete, event favorite toggle) were intentionally left out — the current loading treatment replaces content with spinner + text, which doesn't fit a small icon square without further design work.

Closes #892.