### PR TITLE
fix(email): add time zone parameter

### DIFF
--- a/src/server/api/test/service/vibetype/email.get.ts
+++ b/src/server/api/test/service/vibetype/email.get.ts
@@ -46,6 +46,7 @@ const getDemoEmailProps = (locale: AppLocale) =>
       logoSource,
       locale,
       stackDomain: 'example.com',
+      timeZone: 'Europe/Berlin',
     },
   }) as const
 

--- a/src/server/assets/emails/EmailEventInvitation.vue
+++ b/src/server/assets/emails/EmailEventInvitation.vue
@@ -20,6 +20,7 @@ const {
   eventVisibility,
   locale,
   logoSource = undefined,
+  timeZone = undefined,
 } = defineProps<{
   emailAddress: string
   eventAttendanceType: string
@@ -34,9 +35,10 @@ const {
   eventVisibility: string
   locale: AppLocale
   logoSource?: string
+  timeZone?: string
 }>()
 
-const dateTimeFormatter = getEmailDateTimeFormatter(locale)
+const dateTimeFormatter = getEmailDateTimeFormatter(locale, timeZone)
 const durationFormatter = new Intl.DurationFormat(locale, {
   style: 'long',
 })

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -61,11 +61,16 @@ type EventInvitationEvent = {
   channel: 'event_invitation'
   payload: {
     data: {
-      emailAddress: string
+      contact: {
+        emailAddress: string
+        timeZone: string | null
+      }
       event: Event
       eventCreatorProfilePictureUploadStorageKey: string
       eventCreatorUsername: string
-      guestId: string
+      guest: {
+        id: string
+      }
     }
     template: Template
   }
@@ -350,12 +355,14 @@ export const sendEventInvitationMail = async ({
   const payloadCamelCased = camelcaseKeys(payload, { deep: true })
 
   const {
-    emailAddress,
+    contact,
     event,
-    guestId,
+    guest,
     eventCreatorProfilePictureUploadStorageKey,
     eventCreatorUsername,
   } = payloadCamelCased.data
+  const { emailAddress, timeZone } = contact
+  const guestId = guest.id
 
   const icalFetch = await fetch(
     `http://${SITE_NAME}:3000/api/model/event/ical`,
@@ -482,6 +489,7 @@ export const sendEventInvitationMail = async ({
       eventStart: event.start,
       eventVisibility,
       locale: payloadCamelCased.template.language,
+      timeZone: timeZone || undefined,
     },
     rateLimitPerSecond,
     redis,

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -489,7 +489,7 @@ export const sendEventInvitationMail = async ({
       eventStart: event.start,
       eventVisibility,
       locale: payloadCamelCased.template.language,
-      timeZone: timeZone || undefined,
+      timeZone: timeZone ?? undefined,
     },
     rateLimitPerSecond,
     redis,

--- a/src/shared/utils/dateTime.ts
+++ b/src/shared/utils/dateTime.ts
@@ -100,7 +100,8 @@ export const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
  * Returns a date-time formatter function for use in emails.
  *
  * The formatter uses the specified locale and time zone, falling back to UTC when no time zone
- * is given, e.g. because the receiving contact hasn't set one.
+ * is given, e.g. because the receiving contact hasn't set one, or when the given time zone isn't
+ * a valid IANA time zone name.
  *
  * @param {string} locale - A BCP 47 language tag (e.g., "en-US", "fr-FR") used to format the date/time.
  * @param {string} [timeZone] - An IANA time zone name (e.g., "Europe/Berlin"); defaults to "UTC".
@@ -114,8 +115,21 @@ export const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
 export const getEmailDateTimeFormatter = (
   locale: string,
   timeZone = 'UTC',
-): Intl.DateTimeFormat =>
-  Intl.DateTimeFormat(locale, {
-    ...dateTimeFormatOptions,
-    timeZone,
-  })
+): Intl.DateTimeFormat => {
+  try {
+    return Intl.DateTimeFormat(locale, {
+      ...dateTimeFormatOptions,
+      timeZone,
+    })
+  } catch (error) {
+    if (error instanceof RangeError) {
+      console.warn(`Invalid time zone "${timeZone}", falling back to UTC.`)
+      return Intl.DateTimeFormat(locale, {
+        ...dateTimeFormatOptions,
+        timeZone: 'UTC',
+      })
+    }
+
+    throw error
+  }
+}

--- a/src/shared/utils/dateTime.ts
+++ b/src/shared/utils/dateTime.ts
@@ -97,22 +97,25 @@ export const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
 }
 
 /**
- * Returns a date-time formatter function for use in emails which don't support targeted locales yet.
+ * Returns a date-time formatter function for use in emails.
  *
- * The formatter uses the specified locale and a fixed UTC time zone.
+ * The formatter uses the specified locale and time zone, falling back to UTC when no time zone
+ * is given, e.g. because the receiving contact hasn't set one.
  *
  * @param {string} locale - A BCP 47 language tag (e.g., "en-US", "fr-FR") used to format the date/time.
- * @returns {Intl.DateTimeFormat} A formatter instance that formats dates in the specified locale and UTC time zone.
+ * @param {string} [timeZone] - An IANA time zone name (e.g., "Europe/Berlin"); defaults to "UTC".
+ * @returns {Intl.DateTimeFormat} A formatter instance that formats dates in the specified locale and time zone.
  *
  * @example
- * const format = getEmailDateTimeFormatter('en-US')
+ * const format = getEmailDateTimeFormatter('en-US', 'America/New_York')
  * format.format(new Date('2025-07-15T18:00:00Z'))
- * // → "Jul 15, 2025, 6:00 PM UTC"
+ * // → "Jul 15, 2025, 2:00 PM EDT"
  */
 export const getEmailDateTimeFormatter = (
   locale: string,
+  timeZone = 'UTC',
 ): Intl.DateTimeFormat =>
   Intl.DateTimeFormat(locale, {
     ...dateTimeFormatOptions,
-    timeZone: 'UTC',
+    timeZone,
   })

--- a/tests/unit/shared/utils/dateTime.test.ts
+++ b/tests/unit/shared/utils/dateTime.test.ts
@@ -145,7 +145,18 @@ describe('getEmailDateTimeFormatter', () => {
 
   test('should format date in the given time zone when provided', () => {
     const formatter = getEmailDateTimeFormatter('en-US', 'America/New_York')
-    const formatted = formatter.format(testDate)
-    expect(formatted).toMatch(/Jul \d{1,2}, 2023,? \d{1,2}:\d{2} [AP]M EDT/)
+
+    expect(formatter.resolvedOptions().timeZone).toBe('America/New_York')
+
+    const parts = formatter.formatToParts(testDate)
+    const hourPart = parts.find((part) => part.type === 'hour')
+    const minutePart = parts.find((part) => part.type === 'minute')
+    expect(hourPart?.value).toBe('10')
+    expect(minutePart?.value).toBe('30')
+  })
+
+  test('should fall back to UTC for an invalid time zone', () => {
+    const formatter = getEmailDateTimeFormatter('en-US', 'not-a-time-zone')
+    expect(formatter.resolvedOptions().timeZone).toBe('UTC')
   })
 })

--- a/tests/unit/shared/utils/dateTime.test.ts
+++ b/tests/unit/shared/utils/dateTime.test.ts
@@ -142,4 +142,10 @@ describe('getEmailDateTimeFormatter', () => {
     expect(enFormatted).toContain('UTC')
     expect(frFormatted).toContain('UTC')
   })
+
+  test('should format date in the given time zone when provided', () => {
+    const formatter = getEmailDateTimeFormatter('en-US', 'America/New_York')
+    const formatted = formatter.format(testDate)
+    expect(formatted).toMatch(/Jul \d{1,2}, 2023,? \d{1,2}:\d{2} [AP]M EDT/)
+  })
 })


### PR DESCRIPTION
Wires the receiving contact's time zone through into event invitation emails (`Contact.timeZone`), falling back to UTC when a contact hasn't set one.

Also fixes a latent bug found along the way: sqitch's `invite()` function had already nested the notification payload under `contact`/`guest` (to carry the new time zone alongside the email address), but `notification.ts` still read the old flat shape (`data.emailAddress`/`data.guestId`). That mismatch meant those fields resolved to `undefined` and every event invitation email was silently dropped by the early-return guards.

Resolves https://github.com/maevsi/vibetype/issues/1650