### PR TITLE
fix(modal): replace custom overlay with shadcn-vue dialog

### DIFF
--- a/src/app/components/contact/ContactList.vue
+++ b/src/app/components/contact/ContactList.vue
@@ -50,7 +50,11 @@
           </template>
         </ButtonColored>
       </div>
-      <Modal id="ModalContact" is-footer-hidden @close="onModalContactClose">
+      <Modal
+        v-model="isModalContactOpen"
+        is-footer-hidden
+        @close="onModalContactClose"
+      >
         <FormContact
           :contact="selectedContact"
           @submit-success="onContactSubmitSuccess"
@@ -79,6 +83,7 @@ const store = useStore()
 // data
 const after = ref<string | null>()
 const formContactHeading = ref<string>()
+const isModalContactOpen = ref<boolean>()
 const pending = reactive({
   deletions: ref<string[]>([]),
   edits: ref<string[]>([]),
@@ -149,7 +154,7 @@ const add = () => {
   contactsQuery.pause()
   formContactHeading.value = t('contactAdd')
   selectedContact.value = undefined
-  store.modals.push({ id: 'ModalContact' })
+  isModalContactOpen.value = true
 }
 const delete_ = async (rowId: string) => {
   pending.deletions.push(rowId)
@@ -176,10 +181,10 @@ const edit = (
   pending.edits.push(contact.rowId)
   formContactHeading.value = t('contactEdit')
   selectedContact.value = contact
-  store.modals.push({ id: 'ModalContact' })
+  isModalContactOpen.value = true
 }
 const onContactSubmitSuccess = () => {
-  store.modalRemove('ModalContact')
+  isModalContactOpen.value = false
   after.value = undefined
   contactsQuery.resume()
 }

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -124,7 +124,7 @@
                 :placeholder="dateTimeFormatter(now.toISOString())"
                 readonly
                 type="text"
-                @click="store.modals.push({ id: 'ModalDateTimeStart' })"
+                @click="isModalDateTimeStartOpen = true"
               />
             </FieldContent>
             <FieldError
@@ -149,7 +149,7 @@
                 :placeholder="dateTimeFormatter(now.toISOString())"
                 readonly
                 type="text"
-                @click="store.modals.push({ id: 'ModalDateTimeEnd' })"
+                @click="isModalDateTimeEndOpen = true"
               />
             </FieldContent>
           </Field>
@@ -234,7 +234,7 @@
         </CardStateAlert>
       </div>
     </form>
-    <Modal id="ModalDateTimeStart">
+    <Modal v-model="isModalDateTimeStartOpen">
       <div class="flex justify-center">
         <DatePicker
           :first-day-of-week="2"
@@ -259,7 +259,7 @@
         />
       </div>
     </Modal>
-    <Modal id="ModalDateTimeEnd">
+    <Modal v-model="isModalDateTimeEndOpen">
       <div class="flex justify-center">
         <DatePicker
           :first-day-of-week="2"
@@ -322,6 +322,8 @@ const colorMode = useColorMode()
 const timeZone = useTimeZone()
 
 // data
+const isModalDateTimeEndOpen = ref<boolean>()
+const isModalDateTimeStartOpen = ref<boolean>()
 const now = useNow()
 
 // api data

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -234,7 +234,10 @@
         </CardStateAlert>
       </div>
     </form>
-    <Modal v-model="isModalDateTimeStartOpen">
+    <Modal
+      v-model="isModalDateTimeStartOpen"
+      @submit="isModalDateTimeStartOpen = false"
+    >
       <div class="flex justify-center">
         <DatePicker
           :first-day-of-week="2"
@@ -259,7 +262,10 @@
         />
       </div>
     </Modal>
-    <Modal v-model="isModalDateTimeEndOpen">
+    <Modal
+      v-model="isModalDateTimeEndOpen"
+      @submit="isModalDateTimeEndOpen = false"
+    >
       <div class="flex justify-center">
         <DatePicker
           :first-day-of-week="2"

--- a/src/app/components/guest/GuestList.vue
+++ b/src/app/components/guest/GuestList.vue
@@ -69,7 +69,7 @@
           />
         </div>
       </div>
-      <Modal id="ModalGuest" is-footer-hidden>
+      <Modal v-model="isModalGuestOpen" is-footer-hidden>
         <FormGuest
           :event
           :guest-contact-ids-existing="guests.map((i) => i.contactId)"
@@ -115,12 +115,12 @@ const { event } = defineProps<{
 
 const colorMode = useColorMode()
 const { t } = useI18n()
-const store = useStore()
 const runtimeConfig = useRuntimeConfig()
 const templateDoughnut = useTemplateRef<DoughnutController>('doughnut')
 
 // data
 const after = ref<string | null>()
+const isModalGuestOpen = ref<boolean>()
 const options = {
   plugins: {
     legend: {
@@ -167,10 +167,10 @@ const api = await useApiData([guestsQuery])
 // methods
 const add = () => {
   guestsQuery.pause()
-  store.modals.push({ id: 'ModalGuest' })
+  isModalGuestOpen.value = true
 }
 const onGuestSubmitSuccess = () => {
-  store.modalRemove('ModalGuest')
+  isModalGuestOpen.value = false
   after.value = undefined
   guestsQuery.resume()
 }

--- a/src/app/components/guest/GuestList.vue
+++ b/src/app/components/guest/GuestList.vue
@@ -69,11 +69,15 @@
           />
         </div>
       </div>
-      <Modal v-model="isModalGuestOpen" is-footer-hidden>
+      <Modal
+        v-model="isModalGuestOpen"
+        is-footer-hidden
+        @close="onModalGuestClose"
+      >
         <FormGuest
           :event
           :guest-contact-ids-existing="guests.map((i) => i.contactId)"
-          @submit-success="onGuestSubmitSuccess"
+          @submit-success="onModalGuestClose"
         />
         <template #header>
           {{ t('contactSelect') }}
@@ -169,7 +173,7 @@ const add = () => {
   guestsQuery.pause()
   isModalGuestOpen.value = true
 }
-const onGuestSubmitSuccess = () => {
+const onModalGuestClose = () => {
   isModalGuestOpen.value = false
   after.value = undefined
   guestsQuery.resume()

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -1,33 +1,13 @@
 <template>
-  <div v-if="isVisible">
-    <div
-      class="fixed inset-0 z-10 backdrop-blur-sm backdrop-brightness-50 transition"
-      @click="close"
-    />
-    <Card
-      class="fixed top-[10%] left-1/2 z-20 flex max-h-[80%] w-5/6 -translate-x-1/2 flex-col gap-2 overflow-auto sm:w-2/3 lg:w-1/2 xl:w-1/3"
+  <Dialog :open="isVisible" @update:open="onOpenChange">
+    <DialogContent
+      class="top-[10%] max-h-[80%] w-5/6 max-w-none translate-y-0 flex-col gap-2 overflow-auto rounded-xl border-(--faint-line) bg-(--surface) p-2 shadow-xs sm:w-2/3 sm:max-w-none lg:w-1/2 xl:w-1/3"
     >
-      <div class="flex justify-end">
-        <ButtonIcon
-          :aria-label="t('cancel')"
-          class="invisible"
-          :disabled="isSubmitting"
-          @click="close()"
-        >
-          <AppIconXMark />
-        </ButtonIcon>
-        <h2 v-if="$slots.header" class="m-0 flex-1 px-4 text-center">
-          <slot name="header" />
-        </h2>
-        <ButtonIcon
-          :aria-label="t('cancel')"
-          class="self-start"
-          :disabled="isSubmitting"
-          @click="close()"
-        >
-          <AppIconXMark />
-        </ButtonIcon>
-      </div>
+      <DialogHeader :class="$slots.header ? 'pr-8' : 'sr-only'">
+        <DialogTitle class="text-center">
+          <slot name="header">{{ t('dialog') }}</slot>
+        </DialogTitle>
+      </DialogHeader>
       <div
         class="flex min-h-0 flex-col"
         :class="{
@@ -39,7 +19,7 @@
           <LoaderIndicatorSpinner class="m-auto size-8" />
         </div>
       </div>
-      <div v-if="!isFooterHidden" class="flex justify-center gap-8">
+      <DialogFooter v-if="!isFooterHidden" class="gap-8 sm:justify-center">
         <slot name="footer">
           <ButtonColored
             :aria-label="submitName || t('ok')"
@@ -55,12 +35,12 @@
             </template>
           </ButtonColored>
         </slot>
-      </div>
+      </DialogFooter>
       <CardStateAlert v-if="errors" class="mb-4">
         <AppSpanList :span="errors" />
       </CardStateAlert>
-    </Card>
-  </div>
+    </DialogContent>
+  </Dialog>
 </template>
 
 <script setup lang="ts">
@@ -101,21 +81,9 @@ const close = () => {
 
   store.modalRemove(id)
 }
-const modalKeydowns = (e: KeyboardEvent) => {
-  if (!isVisible.value) {
-    return
-  }
-
-  switch (e.key) {
-    // // Temporarily disabled until https://github.com/maevsi/vibetype/issues/765
-    // case 'Enter': // Enter
-    //   if (!data.isSubmitting && !isSubmitDisabled) {
-    //     methods.submit()
-    //   }
-    //   break
-    case 'Escape': // Escape
-      close()
-      break
+const onOpenChange = (open: boolean) => {
+  if (!open) {
+    close()
   }
 }
 const submit = async () => {
@@ -135,11 +103,7 @@ const submit = async () => {
 
 // lifecycle
 watch(isVisible, (newValue: boolean, _oldvalue) => {
-  if (newValue) {
-    window.addEventListener('keydown', modalKeydowns)
-  } else {
-    window.removeEventListener('keydown', modalKeydowns)
-
+  if (!newValue) {
     errors.value = undefined
     emit('close')
   }
@@ -154,9 +118,9 @@ export default {
 
 <i18n lang="yaml">
 de:
-  cancel: Abbrechen
+  dialog: Dialog
   ok: Ok
 en:
-  cancel: Cancel
+  dialog: Dialog
   ok: Ok
 </i18n>

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -1,5 +1,13 @@
 <template>
-  <Dialog v-model:open="open">
+  <Dialog
+    :open="open"
+    @update:open="
+      (nextOpen) => {
+        if (isSubmitting && !nextOpen) return
+        open = nextOpen
+      }
+    "
+  >
     <DialogContent>
       <DialogHeader :class="$slots.header ? 'px-8' : 'sr-only'">
         <DialogTitle class="text-center">

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -1,9 +1,7 @@
 <template>
   <Dialog v-model:open="open">
-    <DialogContent
-      class="top-[10%] max-h-[80%] w-5/6 max-w-none translate-y-0 flex-col gap-2 overflow-auto rounded-xl border-(--faint-line) bg-(--surface) p-2 shadow-xs sm:w-2/3 sm:max-w-none lg:w-1/2 xl:w-1/3"
-    >
-      <DialogHeader :class="$slots.header ? 'pr-8' : 'sr-only'">
+    <DialogContent>
+      <DialogHeader :class="$slots.header ? 'px-8' : 'sr-only'">
         <DialogTitle class="text-center">
           <slot name="header">{{ t('dialog') }}</slot>
         </DialogTitle>
@@ -15,6 +13,7 @@
         }"
       >
         <slot />
+        <!-- TODO: show submitting state on button, not whole modal -->
         <div v-if="isSubmitting" class="absolute inset-0">
           <LoaderIndicatorSpinner class="m-auto size-8" />
         </div>

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dialog :open="isVisible" @update:open="onOpenChange">
+  <Dialog v-model:open="open">
     <DialogContent
       class="top-[10%] max-h-[80%] w-5/6 max-w-none translate-y-0 flex-col gap-2 overflow-auto rounded-xl border-(--faint-line) bg-(--surface) p-2 shadow-xs sm:w-2/3 sm:max-w-none lg:w-1/2 xl:w-1/3"
     >
@@ -45,13 +45,11 @@
 
 <script setup lang="ts">
 const {
-  id,
   isFooterHidden,
   isSubmitDisabled,
   submitName = undefined,
   submitTaskProvider = () => Promise.resolve(),
 } = defineProps<{
-  id: string
   isFooterHidden?: boolean
   isSubmitDisabled?: boolean
   submitName?: string
@@ -63,28 +61,18 @@ const emit = defineEmits<{
   submitSuccess: [submitSuccess: unknown]
 }>()
 
-const store = useStore()
+const open = defineModel<boolean>()
 const { t } = useI18n()
 
 // data
 const errors = ref()
 const isSubmitting = ref(false)
 
-// computations
-const isVisible = computed(
-  () => store.modals.filter((modal) => modal.id === id).length > 0,
-)
-
 // methods
 const close = () => {
   // NOT = "cancel"! Used by `submit` too.
 
-  store.modalRemove(id)
-}
-const onOpenChange = (open: boolean) => {
-  if (!open) {
-    close()
-  }
+  open.value = false
 }
 const submit = async () => {
   isSubmitting.value = true
@@ -102,7 +90,7 @@ const submit = async () => {
 }
 
 // lifecycle
-watch(isVisible, (newValue: boolean, _oldvalue) => {
+watch(open, (newValue) => {
   if (!newValue) {
     errors.value = undefined
     emit('close')

--- a/src/app/components/modal/Modal.vue
+++ b/src/app/components/modal/Modal.vue
@@ -25,7 +25,7 @@
             :aria-label="submitName || t('ok')"
             :disabled="isSubmitting || isSubmitDisabled"
             type="submit"
-            @click="submit()"
+            @click="emit('submit')"
           >
             {{ submitName || t('ok') }}
             <template #prefix>
@@ -36,9 +36,6 @@
           </ButtonColored>
         </slot>
       </DialogFooter>
-      <CardStateAlert v-if="errors" class="mb-4">
-        <AppSpanList :span="errors" />
-      </CardStateAlert>
     </DialogContent>
   </Dialog>
 </template>
@@ -47,52 +44,26 @@
 const {
   isFooterHidden,
   isSubmitDisabled,
+  isSubmitting,
   submitName = undefined,
-  submitTaskProvider = () => Promise.resolve(),
 } = defineProps<{
   isFooterHidden?: boolean
   isSubmitDisabled?: boolean
+  isSubmitting?: boolean
   submitName?: string
-  submitTaskProvider?: () => Promise<unknown>
 }>()
 
 const emit = defineEmits<{
   close: []
-  submitSuccess: [submitSuccess: unknown]
+  submit: []
 }>()
 
 const open = defineModel<boolean>()
 const { t } = useI18n()
 
-// data
-const errors = ref()
-const isSubmitting = ref(false)
-
-// methods
-const close = () => {
-  // NOT = "cancel"! Used by `submit` too.
-
-  open.value = false
-}
-const submit = async () => {
-  isSubmitting.value = true
-
-  try {
-    const value = await submitTaskProvider()
-    emit('submitSuccess', value)
-    close()
-  } catch (errorsLocal) {
-    errors.value = [errorsLocal]
-    console.error(errorsLocal)
-  }
-
-  isSubmitting.value = false
-}
-
 // lifecycle
 watch(open, (newValue) => {
   if (!newValue) {
-    errors.value = undefined
     emit('close')
   }
 })

--- a/src/app/components/modal/ModalUploadSelection.vue
+++ b/src/app/components/modal/ModalUploadSelection.vue
@@ -1,6 +1,6 @@
 <template>
   <Modal
-    id="ModalUploadSelection"
+    v-model="open"
     :is-submit-disabled="!selectedUploadId"
     @close="selectedUploadId = undefined"
     @submit-success="emit('select', selectedUploadId)"
@@ -19,6 +19,7 @@ const emit = defineEmits<{
   select: [uploadId?: string | null]
 }>()
 
+const open = defineModel<boolean>()
 const { t } = useI18n()
 
 // data

--- a/src/app/components/modal/ModalUploadSelection.vue
+++ b/src/app/components/modal/ModalUploadSelection.vue
@@ -3,7 +3,7 @@
     v-model="open"
     :is-submit-disabled="!selectedUploadId"
     @close="selectedUploadId = undefined"
-    @submit-success="emit('select', selectedUploadId)"
+    @submit="onSubmit"
   >
     <UploadGallery
       is-readonly
@@ -28,6 +28,10 @@ const selectedUploadId = ref<string | null>()
 // methods
 const selectProfilePictureUploadId = (storageKey?: string | null) => {
   selectedUploadId.value = storageKey
+}
+const onSubmit = () => {
+  emit('select', selectedUploadId.value)
+  open.value = false
 }
 </script>
 

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -93,8 +93,9 @@
     </Card>
     <Modal
       v-model="isModalUploadGalleryOpen"
+      :is-submitting="isUploadSubmitting"
       :submit-name="t('upload')"
-      :submit-task-provider="getUploadBlobPromise"
+      @submit="onUploadSubmit"
     >
       <Cropper
         ref="cropper"
@@ -104,6 +105,9 @@
           aspectRatio: 1,
         }"
       />
+      <CardStateAlert v-if="uploadSubmitErrors" class="mb-4">
+        <AppSpanList :span="uploadSubmitErrors" />
+      </CardStateAlert>
       <template #header>{{ t('uploadNew') }}</template>
       <template #submit-icon><AppIconArrowUpTray /></template>
     </Modal>
@@ -145,6 +149,8 @@ const after = ref<string | null>()
 const fileSelectedUrl = ref<string>()
 const fileSelectedMimeType = ref<string>()
 const isModalUploadGalleryOpen = ref<boolean>()
+const isUploadSubmitting = ref(false)
+const uploadSubmitErrors = ref()
 const pending = reactive({
   deletions: ref<string[]>([]),
 })
@@ -337,7 +343,7 @@ const toggleSelect = (upload: UnwrapRef<typeof selectedItem>) => {
     emit('selection', selectedItem.value?.rowId)
   }
 }
-const getUploadBlobPromise = () =>
+const uploadBlobPromise = () =>
   new Promise<void>((resolve, reject) => {
     ;(templateCropper.value?.getResult() as CropperResult).canvas?.toBlob(
       async (blob) => {
@@ -415,6 +421,20 @@ const getUploadBlobPromise = () =>
       'image/jpeg',
     )
   })
+const onUploadSubmit = async () => {
+  isUploadSubmitting.value = true
+  uploadSubmitErrors.value = undefined
+
+  try {
+    await uploadBlobPromise()
+    isModalUploadGalleryOpen.value = false
+  } catch (errorsLocal) {
+    uploadSubmitErrors.value = [errorsLocal]
+    console.error(errorsLocal)
+  }
+
+  isUploadSubmitting.value = false
+}
 </script>
 
 <style>

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -429,7 +429,9 @@ const onUploadSubmit = async () => {
     await uploadBlobPromise()
     isModalUploadGalleryOpen.value = false
   } catch (errorsLocal) {
-    uploadSubmitErrors.value = [errorsLocal]
+    uploadSubmitErrors.value = [
+      errorsLocal instanceof Error ? errorsLocal.message : String(errorsLocal),
+    ]
     console.error(errorsLocal)
   }
 

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -92,7 +92,7 @@
       </div>
     </Card>
     <Modal
-      id="ModalUploadGallery"
+      v-model="isModalUploadGalleryOpen"
       :submit-name="t('upload')"
       :submit-task-provider="getUploadBlobPromise"
     >
@@ -144,6 +144,7 @@ const templateInputProfilePicture = useTemplateRef('inputProfilePicture')
 const after = ref<string | null>()
 const fileSelectedUrl = ref<string>()
 const fileSelectedMimeType = ref<string>()
+const isModalUploadGalleryOpen = ref<boolean>()
 const pending = reactive({
   deletions: ref<string[]>([]),
 })
@@ -320,7 +321,7 @@ const loadProfilePicture = (event: Event) => {
         e.target?.result as ArrayBuffer,
         file.type,
       )
-      store.modals.push({ id: 'ModalUploadGallery' })
+      isModalUploadGalleryOpen.value = true
     }
     fileReader.readAsDataURL(file)
   } catch (error) {

--- a/src/app/pages/account/edit/[username].vue
+++ b/src/app/pages/account/edit/[username].vue
@@ -55,7 +55,10 @@
             </TypographyLabel>
           </ButtonColored>
         </div>
-        <ModalUploadSelection @select="onUploadSelect" />
+        <ModalUploadSelection
+          v-model="isModalUploadSelectionOpen"
+          @select="onUploadSelect"
+        />
       </div>
       <AppInputTextarea
         :content-initial="account.description"
@@ -151,8 +154,9 @@ const executeUrqlRequest = useExecuteUrqlRequest()
 const account = computed(() => api.value.data.accountByUsername)
 
 // profile picture
+const isModalUploadSelectionOpen = ref<boolean>()
 const showModalUploadSelection = () => {
-  store.modals.push({ id: 'ModalUploadSelection' })
+  isModalUploadSelectionOpen.value = true
 }
 
 const createProfilePictureMutation = useMutation(

--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -41,6 +41,7 @@
       <Modal
         v-model="isModalAttendanceScanQrCodeOpen"
         :submit-name="t('close')"
+        @submit="modalClose"
       >
         <LazyAppQrCodeStream @detect="onDetect" @error="modalClose" />
         <template #submit-icon>

--- a/src/app/pages/event/view/[username]/[event_name]/attendance.vue
+++ b/src/app/pages/event/view/[username]/[event_name]/attendance.vue
@@ -38,7 +38,10 @@
           </CardStateAlert>
         </div>
       </div>
-      <Modal id="ModalAttendanceScanQrCode" :submit-name="t('close')">
+      <Modal
+        v-model="isModalAttendanceScanQrCodeOpen"
+        :submit-name="t('close')"
+      >
         <LazyAppQrCodeStream @detect="onDetect" @error="modalClose" />
         <template #submit-icon>
           <AppIconXCircleSolid />
@@ -112,10 +115,13 @@ const title = computed(() => {
 useHeadDefault({ title })
 
 // qr code
+const isModalAttendanceScanQrCodeOpen = ref<boolean>()
 const qrCodeScan = () => {
-  store.modals.push({ id: 'ModalAttendanceScanQrCode' })
+  isModalAttendanceScanQrCodeOpen.value = true
 }
-const modalClose = () => store.modalRemove('ModalAttendanceScanQrCode')
+const modalClose = () => {
+  isModalAttendanceScanQrCodeOpen.value = false
+}
 const guestId = ref<string>()
 const executeUrqlRequest = useExecuteUrqlRequest()
 const createAttendanceMutation = useMutation(

--- a/src/app/pages/guest/view/[id]/index.vue
+++ b/src/app/pages/guest/view/[id]/index.vue
@@ -249,7 +249,7 @@
         <!-- eslint-enable vue/no-v-html -->
       </Card>
     </div>
-    <Modal id="ModalGuestQrCode">
+    <Modal v-model="isModalGuestQrCodeOpen">
       <div v-if="guest" class="flex flex-col items-center gap-2 pb-4">
         <div class="bg-white p-4">
           <QrcodeVue id="qrCode" :size="200" :value="guest.rowId" />
@@ -273,7 +273,7 @@
         </ButtonColored>
         <ButtonColored
           :aria-label="t('close')"
-          @click="store.modalRemove('ModalGuestQrCode')"
+          @click="isModalGuestQrCodeOpen = false"
         >
           {{ t('close') }}
           <template #prefix>
@@ -315,6 +315,7 @@ const updateGuestByRowIdMutation = useMutation(
 )
 const store = useStore()
 
+const isModalGuestQrCodeOpen = ref<boolean>()
 const isOpenReportDrawer = ref<boolean>()
 const alertError = useAlertError()
 
@@ -458,7 +459,7 @@ const print = () => {
   })
 }
 const qrCodeShow = () => {
-  store.modals.push({ id: 'ModalGuestQrCode' })
+  isModalGuestQrCodeOpen.value = true
 }
 const update = async (id: string, guestPatch: GuestPatch) => {
   const result = await updateGuestByRowIdMutation.executeMutation({

--- a/src/app/stores/store.ts
+++ b/src/app/stores/store.ts
@@ -3,14 +3,11 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { RouteNamedMapI18n } from 'vue-router/auto-routes'
 
-import type { Modal } from '~/types/modal'
-
 export const useStore = defineStore(SITE_NAME, () => {
   const localePath = useLocalePath()
 
   // const jwt = ref<string>() // we don't store the JWT itself for security reasons
   const jwtPayload = ref<Jwt>()
-  const modals = ref<Modal[]>([])
   const routeHistory = ref<string[]>([])
   const routeHistoryDisabled = ref<boolean>(false)
   const signedInAccountId = ref<string>()
@@ -44,12 +41,6 @@ export const useStore = defineStore(SITE_NAME, () => {
     }
   }
 
-  const modalRemove = (modalId: string) => {
-    modals.value = modals.value.filter((modal) => {
-      return modal.id !== modalId
-    })
-  }
-
   const navigateBack = async () => {
     routeHistoryDisabled.value = true
     await navigateTo(
@@ -62,14 +53,12 @@ export const useStore = defineStore(SITE_NAME, () => {
 
   return {
     jwtPayload,
-    modals,
     routeHistory,
     routeHistoryDisabled,
     signedInAccountId,
     signedInUsername,
     jwtRemove,
     jwtSet,
-    modalRemove,
     navigateBack,
   }
 })

--- a/src/app/types/modal.d.ts
+++ b/src/app/types/modal.d.ts
@@ -1,3 +1,0 @@
-export interface Modal {
-  id: string
-}


### PR DESCRIPTION
This pull request refactors the modal handling system across the application to use Vue's `v-model` for controlling modal visibility, replacing the previous centralized store-based approach. It also updates the `Modal.vue` component to use headless UI dialog primitives, simplifies its API, and adapts all modal usages throughout the codebase to the new interface. Additionally, error handling and submission logic for modals are improved and made more explicit at the component level.

**Modal System Refactor**

* Refactored the `Modal.vue` component to use headless UI's `Dialog` and `DialogContent` for accessibility and better state management, replacing the custom modal visibility logic and store-based tracking. The modal is now controlled via a `v-model` boolean.
* Updated all usages of the `Modal` component in various files (e.g., `ContactList.vue`, `GuestList.vue`, `FormEvent.vue`, `UploadGallery.vue`, `ModalUploadSelection.vue`, and several page components) to use the new `v-model`-based visibility control, replacing store-based modal opening/closing.

**Component API and Logic Improvements**

* Simplified the `Modal.vue` API: removed the `id`, `submitTaskProvider`, and store dependency; submission and closing are now handled via explicit events and local state.
* Updated modal submission and error handling to be managed at the component level (e.g., `UploadGallery.vue`, `ModalUploadSelection.vue`), improving clarity and flexibility.

**State Management and Cleanup**

* Replaced all modal open/close logic that used `store.modals.push` and `store.modalRemove` with direct manipulation of local `ref` booleans for each modal, reducing global state complexity.

**UI/UX Improvements**

* Improved modal accessibility and structure by using headless UI dialog primitives and ensuring dialog headers and footers are more semantically correct.

**Internationalization**

* Updated modal-related i18n strings to reflect the new dialog terminology.
