### PR TITLE
chore(sentry): make release name resilient to missing tags

### DIFF
--- a/src/modules/release.ts
+++ b/src/modules/release.ts
@@ -7,6 +7,9 @@ export default defineNuxtModule({
     name: 'release',
   },
   async setup(_moduleOptions, nuxt) {
-    nuxt.options.runtimeConfig.public.vio.releaseName = await RELEASE_NAME()
+    const releaseName = await RELEASE_NAME()
+    if (!releaseName) return
+
+    nuxt.options.runtimeConfig.public.vio.releaseName = releaseName
   },
 })

--- a/src/node/process.ts
+++ b/src/node/process.ts
@@ -3,6 +3,12 @@ import { promisify } from 'node:util'
 
 const execPromise = promisify(exec)
 
-export const RELEASE_NAME = async () =>
-  process.env.RELEASE_NAME ||
-  (await execPromise('git describe --tags')).stdout.trim()
+export const RELEASE_NAME = async () => {
+  if (process.env.RELEASE_NAME) return process.env.RELEASE_NAME
+
+  try {
+    return (await execPromise('git describe --tags')).stdout.trim()
+  } catch {
+    return undefined
+  }
+}

--- a/src/server/middleware/headers.ts
+++ b/src/server/middleware/headers.ts
@@ -1,6 +1,15 @@
 export default defineEventHandler((event) => {
   const runtimeConfig = useRuntimeConfig()
 
+  const securityEndpointParams = [
+    `sentry_key=${runtimeConfig.public.sentry.project.publicKey}`,
+    `sentry_environment=${runtimeConfig.public.vio.environment}`,
+    runtimeConfig.public.vio.releaseName &&
+      `sentry_release=${runtimeConfig.public.vio.releaseName}`,
+  ]
+    .filter(Boolean)
+    .join('&')
+
   appendHeader(
     event,
     'NEL',
@@ -9,6 +18,6 @@ export default defineEventHandler((event) => {
   appendHeader(
     event,
     'Report-To',
-    `'{"group":"default","max_age":31536000,"endpoints":[{"url":"https://${runtimeConfig.public.sentry.host}/api/${runtimeConfig.public.sentry.project.id}/security/?sentry_key=${runtimeConfig.public.sentry.project.publicKey}&sentry_environment=${runtimeConfig.public.vio.environment}&sentry_release=${runtimeConfig.public.vio.releaseName}"}],"include_subdomains":true}'`,
+    `'{"group":"default","max_age":31536000,"endpoints":[{"url":"https://${runtimeConfig.public.sentry.host}/api/${runtimeConfig.public.sentry.project.id}/security/?${securityEndpointParams}"}],"include_subdomains":true}'`,
   )
 })


### PR DESCRIPTION
This pull request improves the handling of release name resolution and refactors how Sentry endpoint parameters are constructed for security reporting. The main focus is on making the code more robust and maintainable by handling errors gracefully and reducing duplication in constructing query parameters.

**Release name resolution:**

* Refactored the `RELEASE_NAME` async function in `src/node/process.ts` to handle errors gracefully when running the `git describe --tags` command, returning `undefined` if the command fails instead of throwing an error.

**Sentry security endpoint parameter construction:**

* In `src/server/middleware/headers.ts`, extracted the construction of Sentry endpoint query parameters into a reusable `securityEndpointParams` variable, which filters out falsy values and joins them with `&`.
* Updated the `Report-To` header construction to use the new `securityEndpointParams` variable, reducing duplication and improving maintainability.