### PR TITLE
refactor(event): replace v-calendar date and time picker with shadcn-vue components

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,9 +641,6 @@ importers:
       unplugin-vue-components:
         specifier: 32.1.0
         version: 32.1.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))))(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
-      v-calendar:
-        specifier: 3.1.2
-        version: 3.1.2(@popperjs/core@2.11.8)(vue@3.5.40(typescript@6.0.3))
       vaul-vue:
         specifier: 0.4.1
         version: 0.4.1(reka-ui@2.10.1(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
@@ -774,6 +771,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.64':
     resolution: {integrity: sha512-bilBheDT6GKnFkPnovgt1HL5spmnTCntm8w+hO3bmjnlZ8qMhqfQ1RJYPRTNsPlXaCcBXWUtg+zn/NM6WQUXoA==}
@@ -4472,9 +4472,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@popperjs/core@2.11.8':
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -5711,9 +5708,6 @@ packages:
 
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
-
-  '@types/resize-observer-browser@0.1.11':
-    resolution: {integrity: sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -7170,15 +7164,6 @@ packages:
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
-
-  date-fns-tz@2.0.1:
-    resolution: {integrity: sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==}
-    peerDependencies:
-      date-fns: 2.x
-
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -12033,12 +12018,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  v-calendar@3.1.2:
-    resolution: {integrity: sha512-QDWrnp4PWCpzUblctgo4T558PrHgHzDtQnTeUNzKxfNf29FkCeFpwGd9bKjAqktaa2aJLcyRl45T5ln1ku34kg==}
-    peerDependencies:
-      '@popperjs/core': ^2.0.0
-      vue: ^3.2.0
-
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
@@ -12308,11 +12287,6 @@ packages:
         optional: true
       vite:
         optional: true
-
-  vue-screen-utils@1.0.0-beta.13:
-    resolution: {integrity: sha512-EJ/8TANKhFj+LefDuOvZykwMr3rrLFPLNb++lNBqPOpVigT2ActRg6icH9RFQVm4nHwlHIHSGm5OY/Clar9yIg==}
-    peerDependencies:
-      vue: ^3.2.0
 
   vue-sonner@2.0.9:
     resolution: {integrity: sha512-i6BokNlNDL93fpzNxN/LZSn6D6MzlO+i3qXt6iVZne3x1k7R46d5HlFB4P8tYydhgqOrRbIZEsnRd3kG7qGXyw==}
@@ -17500,8 +17474,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@popperjs/core@2.11.8': {}
-
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -18613,8 +18585,6 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.6
     optional: true
-
-  '@types/resize-observer-browser@0.1.11': {}
 
   '@types/resolve@1.20.2': {}
 
@@ -20254,14 +20224,6 @@ snapshots:
       is-data-view: 1.0.2
 
   dataloader@2.2.3: {}
-
-  date-fns-tz@2.0.1(date-fns@2.30.0):
-    dependencies:
-      date-fns: 2.30.0
-
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.29.7
 
   db0@0.3.4: {}
 
@@ -26545,17 +26507,6 @@ snapshots:
   uuid@9.0.1:
     optional: true
 
-  v-calendar@3.1.2(@popperjs/core@2.11.8)(vue@3.5.40(typescript@6.0.3)):
-    dependencies:
-      '@popperjs/core': 2.11.8
-      '@types/lodash': 4.17.25
-      '@types/resize-observer-browser': 0.1.11
-      date-fns: 2.30.0
-      date-fns-tz: 2.0.1(date-fns@2.30.0)
-      lodash: 4.18.1
-      vue: 3.5.40(typescript@6.0.3)
-      vue-screen-utils: 1.0.0-beta.13(vue@3.5.40(typescript@6.0.3))
-
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
@@ -26809,10 +26760,6 @@ snapshots:
       - rollup
       - unloader
       - webpack
-
-  vue-screen-utils@1.0.0-beta.13(vue@3.5.40(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.40(typescript@6.0.3)
 
   vue-sonner@2.0.9(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))))(@nuxt/schema@4.5.1)(nuxt@4.5.1(a9ecc9fa534f979236a6e5da8fb7a770)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       eslint-plugin-prettier:
         specifier: 5.5.6
         version: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2)))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(prettier@3.9.6)
+      jose:
+        specifier: 6.2.7
+        version: 6.2.7
       typescript:
         specifier: 6.0.3
         version: 6.0.3

--- a/src/app/components/app/AppTimeField.vue
+++ b/src/app/components/app/AppTimeField.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { TimeFieldRoot, useForwardPropsEmits } from 'reka-ui'
+import type { TimeFieldRootEmits, TimeFieldRootProps } from 'reka-ui'
+import { cn } from '@/utils/shadcn'
+
+const props = defineProps<
+  TimeFieldRootProps & { class?: HTMLAttributes['class'] }
+>()
+const emits = defineEmits<TimeFieldRootEmits>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <TimeFieldRoot
+    v-slot="{ segments }"
+    :class="
+      cn(
+        'border-input flex h-9 w-fit items-center gap-1 rounded-md border bg-(--neutral-level-1) px-3 py-1 text-base shadow-xs outline-none md:text-sm',
+        'focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]',
+        'data-[invalid]:ring-destructive/20 dark:data-[invalid]:ring-destructive/40 data-[invalid]:border-destructive',
+        props.class,
+      )
+    "
+    data-slot="time-field"
+    v-bind="forwarded"
+  >
+    <AppTimeFieldSegment
+      v-for="segment in segments"
+      :key="segment.part"
+      :part="segment.part"
+      :value="segment.value"
+    />
+  </TimeFieldRoot>
+</template>

--- a/src/app/components/app/AppTimeFieldSegment.vue
+++ b/src/app/components/app/AppTimeFieldSegment.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { SegmentPart } from 'reka-ui'
+import { TimeFieldInput } from 'reka-ui'
+import { cn } from '@/utils/shadcn'
+
+const { part, value = undefined } = defineProps<{
+  part: SegmentPart
+  value?: string
+}>()
+</script>
+
+<template>
+  <TimeFieldInput
+    :class="
+      cn(
+        'rounded-sm p-0.5 text-center tabular-nums outline-none',
+        'focus:bg-accent focus:text-accent-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        part === 'literal' ? 'text-muted-foreground px-0' : 'min-w-6',
+      )
+    "
+    data-slot="time-field-input"
+    :part
+  >
+    {{ value }}
+  </TimeFieldInput>
+</template>

--- a/src/app/components/event/dashlet/EventDashletDuration.vue
+++ b/src/app/components/event/dashlet/EventDashletDuration.vue
@@ -19,7 +19,7 @@ const formatDuration = ({
   duration,
   locale,
 }: {
-  duration: Duration
+  duration: ReturnType<typeof getDuration>
   locale: string
 }) => {
   if (typeof Intl === 'undefined' || !('DurationFormat' in Intl)) return // TODO: evaluate polyfill

--- a/src/app/components/form/FormEvent.vue
+++ b/src/app/components/form/FormEvent.vue
@@ -136,18 +136,60 @@
           </Field>
         </form.Field>
         <form.Field v-slot="{ field }" name="start">
-          <Field>
-            <FieldLabel for="input-start">{{ t('start') }}</FieldLabel>
+          <Field class="flex flex-col">
+            <FieldLabel for="button-start">{{ t('start') }}</FieldLabel>
             <FieldContent>
-              <Input
-                id="input-start"
-                :aria-invalid="isFieldInvalid(field)"
-                :model-value="dateTimeFormatter(field.state.value)"
-                :placeholder="dateTimeFormatter(now.toISOString())"
-                readonly
-                type="text"
-                @click="isModalDateTimeStartOpen = true"
-              />
+              <Popover>
+                <PopoverTrigger as-child>
+                  <Button
+                    id="button-start"
+                    :aria-invalid="isFieldInvalid(field)"
+                    :class="
+                      cn(
+                        'justify-start text-start font-normal',
+                        !field.state.value && 'text-muted-foreground',
+                      )
+                    "
+                    variant="outline"
+                  >
+                    {{
+                      dateTimeFormatter(field.state.value) ??
+                      dateTimeFormatter(now.toISOString())
+                    }}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent class="w-auto p-0">
+                  <div
+                    class="flex max-h-(--reka-popover-content-available-height) flex-col items-center gap-3 overflow-y-auto p-3"
+                  >
+                    <AppCalendar
+                      :max-value="
+                        form.getFieldValue('end')
+                          ? isoToCalendarDateTime(form.getFieldValue('end'))
+                          : undefined
+                      "
+                      :model-value="isoToCalendarDateTime(field.state.value)"
+                      :week-starts-on="1"
+                      @update:model-value="
+                        (date) => applyDateSelection(field, date)
+                      "
+                    />
+                    <AppTimeField
+                      :locale
+                      :model-value="isoToCalendarDateTime(field.state.value)"
+                      :placeholder="
+                        isoToCalendarDateTime(field.state.value) ??
+                        nowCalendarDateTime
+                      "
+                      :step="{ minute: 5 }"
+                      step-snapping
+                      @update:model-value="
+                        (time) => applyTimeSelection(field, time)
+                      "
+                    />
+                  </div>
+                </PopoverContent>
+              </Popover>
             </FieldContent>
             <FieldError
               v-if="isFieldInvalid(field)"
@@ -162,17 +204,59 @@
           </Field>
         </form.Field>
         <form.Field v-slot="{ field }" name="end">
-          <Field>
-            <FieldLabel for="input-end">{{ t('end') }}</FieldLabel>
+          <Field class="flex flex-col">
+            <FieldLabel for="button-end">{{ t('end') }}</FieldLabel>
             <FieldContent>
-              <Input
-                id="input-end"
-                :model-value="dateTimeFormatter(field.state.value)"
-                :placeholder="dateTimeFormatter(now.toISOString())"
-                readonly
-                type="text"
-                @click="isModalDateTimeEndOpen = true"
-              />
+              <Popover>
+                <PopoverTrigger as-child>
+                  <Button
+                    id="button-end"
+                    :class="
+                      cn(
+                        'justify-start text-start font-normal',
+                        !field.state.value && 'text-muted-foreground',
+                      )
+                    "
+                    variant="outline"
+                  >
+                    {{
+                      dateTimeFormatter(field.state.value) ??
+                      dateTimeFormatter(now.toISOString())
+                    }}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent class="w-auto p-0">
+                  <div
+                    class="flex max-h-(--reka-popover-content-available-height) flex-col items-center gap-3 overflow-y-auto p-3"
+                  >
+                    <AppCalendar
+                      :min-value="
+                        form.getFieldValue('start')
+                          ? isoToCalendarDateTime(form.getFieldValue('start'))
+                          : undefined
+                      "
+                      :model-value="isoToCalendarDateTime(field.state.value)"
+                      :week-starts-on="1"
+                      @update:model-value="
+                        (date) => applyDateSelection(field, date)
+                      "
+                    />
+                    <AppTimeField
+                      :locale
+                      :model-value="isoToCalendarDateTime(field.state.value)"
+                      :placeholder="
+                        isoToCalendarDateTime(field.state.value) ??
+                        nowCalendarDateTime
+                      "
+                      :step="{ minute: 5 }"
+                      step-snapping
+                      @update:model-value="
+                        (time) => applyTimeSelection(field, time)
+                      "
+                    />
+                  </div>
+                </PopoverContent>
+              </Popover>
             </FieldContent>
           </Field>
         </form.Field>
@@ -257,71 +341,24 @@
         </CardStateAlert>
       </div>
     </form>
-    <Modal
-      v-model="isModalDateTimeStartOpen"
-      @submit="isModalDateTimeStartOpen = false"
-    >
-      <div class="flex justify-center">
-        <DatePicker
-          :first-day-of-week="2"
-          :is-dark="colorMode.value === 'dark'"
-          :is24hr="locale !== 'en'"
-          :locale
-          :masks="{ input: 'YYYY-MM-DD h:mm A' }"
-          :max-date="form.getFieldValue('end') || undefined"
-          :minute-increment="5"
-          mode="dateTime"
-          :model-value="
-            form.getFieldValue('start')
-              ? new Date(form.getFieldValue('start'))
-              : null
-          "
-          @update:model-value="
-            form.setFieldValue(
-              'start',
-              ($event as Date | null)?.toISOString() ?? '',
-            )
-          "
-        />
-      </div>
-    </Modal>
-    <Modal
-      v-model="isModalDateTimeEndOpen"
-      @submit="isModalDateTimeEndOpen = false"
-    >
-      <div class="flex justify-center">
-        <DatePicker
-          :first-day-of-week="2"
-          :is-dark="colorMode.value === 'dark'"
-          :is24hr="locale !== 'en'"
-          :locale
-          :masks="{ input: 'YYYY-MM-DD h:mm A' }"
-          :min-date="form.getFieldValue('start') || undefined"
-          :minute-increment="5"
-          mode="dateTime"
-          :model-value="
-            form.getFieldValue('end')
-              ? new Date(form.getFieldValue('end'))
-              : null
-          "
-          @update:model-value="
-            form.setFieldValue(
-              'end',
-              ($event as Date | null)?.toISOString() ?? '',
-            )
-          "
-        />
-      </div>
-    </Modal>
   </div>
 </template>
 
 <script setup lang="ts">
+import type { DateValue, TimeValue } from 'reka-ui'
+import {
+  fromDate,
+  getLocalTimeZone,
+  parseAbsoluteToLocal,
+  toCalendarDateTime,
+} from '@internationalized/date'
+import { toDate } from 'reka-ui/date'
 import { useForm } from '@tanstack/vue-form'
 import type { AnyFieldApi } from '@tanstack/vue-form'
 import { useMutation } from '@urql/vue'
 import { z } from 'zod'
-import { DatePicker } from 'v-calendar'
+
+import { cn } from '@/utils/shadcn'
 
 import { graphql } from '~~/gql/generated'
 import { EventVisibility } from '~~/gql/generated/graphcache'
@@ -354,12 +391,9 @@ const { event = undefined } = defineProps<{
 const localePath = useLocalePath()
 const { locale, t } = useI18n()
 const store = useStore()
-const colorMode = useColorMode()
 const timeZone = useTimeZone()
 
 // data
-const isModalDateTimeEndOpen = ref<boolean>()
-const isModalDateTimeStartOpen = ref<boolean>()
 const now = useNow()
 
 // api data
@@ -694,6 +728,32 @@ const dateTimeFormatter = (x?: string) =>
         timeZone,
       })
     : undefined
+const isoToCalendarDateTime = (value?: string) =>
+  value ? toCalendarDateTime(parseAbsoluteToLocal(value)) : undefined
+const applyDateSelection = (field: AnyFieldApi, date?: DateValue) => {
+  if (!date) {
+    field.handleChange('')
+    return
+  }
+
+  const time =
+    isoToCalendarDateTime(field.state.value) ?? nowCalendarDateTime.value
+  field.handleChange(
+    toDate(toCalendarDateTime(date, time), getLocalTimeZone()).toISOString(),
+  )
+}
+const applyTimeSelection = (field: AnyFieldApi, time?: TimeValue) => {
+  if (!time) {
+    field.handleChange('')
+    return
+  }
+
+  const date =
+    isoToCalendarDateTime(field.state.value) ?? nowCalendarDateTime.value
+  field.handleChange(
+    toDate(toCalendarDateTime(date, time), getLocalTimeZone()).toISOString(),
+  )
+}
 const onInputName = async (value: string, nameField: AnyFieldApi) => {
   nameField.handleChange(value)
   await updateSlug()
@@ -711,6 +771,9 @@ const updateSlug = async () => {
 }
 
 // computations
+const nowCalendarDateTime = computed(() =>
+  toCalendarDateTime(fromDate(now.value, getLocalTimeZone())),
+)
 const isWarningStartPastShown = computed(() => {
   const start = form.getFieldValue('start')
   return !!start && new Date(start) < now.value
@@ -724,10 +787,6 @@ if (event?.rowId) {
   form.setFieldValue('rowId', event.rowId)
 }
 </script>
-
-<style>
-@import url('~~/node_modules/v-calendar/dist/style.css');
-</style>
 
 <i18n lang="yaml">
 de:

--- a/src/nuxt.config.ts
+++ b/src/nuxt.config.ts
@@ -248,7 +248,6 @@ export default defineNuxtConfig({
         'tailwind-merge',
         'tailwindcss/colors',
         'ua-parser-js',
-        'v-calendar',
         'vaul-vue',
         'vue-advanced-cropper',
         'vue-chartjs',

--- a/src/package.json
+++ b/src/package.json
@@ -145,7 +145,6 @@
     "ufo": "1.6.4",
     "unplugin-icons": "23.0.1",
     "unplugin-vue-components": "32.1.0",
-    "v-calendar": "3.1.2",
     "vaul-vue": "0.4.1",
     "vue": "3.5.40",
     "vue-advanced-cropper": "2.8.9",

--- a/src/server/api/test/service/postgraphile/graphql.get.ts
+++ b/src/server/api/test/service/postgraphile/graphql.get.ts
@@ -1,8 +1,7 @@
-const ACCOUNT_ROW_ID = 'a3f8f6c2-6b1e-4b6a-9b9a-9f7d6a2e6c1a'
-const ACCOUNT_ID =
-  'QWNjb3VudDphM2Y4ZjZjMi02YjFlLTRiNmEtOWI5YS05ZjdkNmEyZTZjMWE='
-const ACCOUNT_USERNAME = 'e2e-test-account'
-const ACCOUNT_DESCRIPTION = 'Building vibetype, one event at a time.'
+const ACCOUNT_ROW_ID = TESTING_ACCOUNT_ROW_ID
+const ACCOUNT_ID = TESTING_ACCOUNT_ID
+const ACCOUNT_USERNAME = TESTING_ACCOUNT_USERNAME
+const ACCOUNT_DESCRIPTION = TESTING_ACCOUNT_DESCRIPTION
 
 export default defineEventHandler((event) => {
   const isTesting = useIsTesting({ isCookieEnabled: false })
@@ -48,6 +47,50 @@ export default defineEventHandler((event) => {
             rowId: ACCOUNT_ROW_ID,
             username: ACCOUNT_USERNAME,
             __typename: 'Account',
+          },
+        },
+      }
+    case 'AllEventCategoriesFormEvent':
+      return {
+        data: {
+          allEventCategories: {
+            nodes: [
+              {
+                id: 'RXZlbnRDYXRlZ29yeToxMTExMTExMS0xMTExLTExMTEtMTExMS0xMTExMTExMTExMTE=',
+                name: 'music-and-entertainment',
+                rowId: '11111111-1111-1111-1111-111111111111',
+                __typename: 'EventCategory',
+              },
+              {
+                id: 'RXZlbnRDYXRlZ29yeToyMjIyMjIyMi0yMjIyLTIyMjItMjIyMi0yMjIyMjIyMjIyMjI=',
+                name: 'sports-and-fitness',
+                rowId: '22222222-2222-2222-2222-222222222222',
+                __typename: 'EventCategory',
+              },
+            ],
+            __typename: 'EventCategoryConnection',
+          },
+        },
+      }
+    case 'AllEventFormatsFormEvent':
+      return {
+        data: {
+          allEventFormats: {
+            nodes: [
+              {
+                id: 'RXZlbnRGb3JtYXQ6MzMzMzMzMzMtMzMzMy0zMzMzLTMzMzMtMzMzMzMzMzMzMzMz',
+                name: 'meetup',
+                rowId: '33333333-3333-3333-3333-333333333333',
+                __typename: 'EventFormat',
+              },
+              {
+                id: 'RXZlbnRGb3JtYXQ6NDQ0NDQ0NDQtNDQ0NC00NDQ0LTQ0NDQtNDQ0NDQ0NDQ0NDQ0',
+                name: 'workshop',
+                rowId: '44444444-4444-4444-4444-444444444444',
+                __typename: 'EventFormat',
+              },
+            ],
+            __typename: 'EventFormatConnection',
           },
         },
       }

--- a/src/shared/utils/jwt.ts
+++ b/src/shared/utils/jwt.ts
@@ -12,6 +12,8 @@ export const getJwtPublicKey = async ({
 }: {
   runtimeConfig: ReturnType<typeof useRuntimeConfig>
 }) => {
+  if (runtimeConfig.public.vio.isTesting) return TESTING_JWT_PUBLIC_KEY
+
   if (runtimeConfig.public.vio.stagingHost) {
     return await $fetch<string>(
       `https://${runtimeConfig.public.vio.stagingHost}/api/service/postgraphile/jwt-public-key`,

--- a/src/shared/utils/testing.ts
+++ b/src/shared/utils/testing.ts
@@ -1,0 +1,22 @@
+export const TESTING_ACCOUNT_ROW_ID = 'a3f8f6c2-6b1e-4b6a-9b9a-9f7d6a2e6c1a'
+export const TESTING_ACCOUNT_ID =
+  'QWNjb3VudDphM2Y4ZjZjMi02YjFlLTRiNmEtOWI5YS05ZjdkNmEyZTZjMWE='
+export const TESTING_ACCOUNT_USERNAME = 'e2e-test-account'
+export const TESTING_ACCOUNT_DESCRIPTION =
+  'Building vibetype, one event at a time.'
+
+// Test-only ES256 key pair used to sign and verify JSON web tokens while
+// `isTesting` is active, so e2e specs can sign in without a real
+// postgraphile instance. Never used unless the testing flag is on, so it
+// carries no production trust and is safe to commit.
+export const TESTING_JWT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1QI8ralafKPzwdy4YlATA3yro5oi
+/7vlgZzdIzkoq2sAaw2S4I6rjNZF9G1AvdRzyYXJJHm8oyjrMY54Hv90SQ==
+-----END PUBLIC KEY-----
+`
+export const TESTING_JWT_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQguPdjPulHNvhoPJXG
+T/7rEDXwXK1X0Qetqx7cSFYWOHGhRANCAATVAjytqVp8o/PB3LhiUBMDfKujmiL/
+u+WBnN0jOSirawBrDZLgjquM1kX0bUC91HPJhckkebyjKOsxjnge/3RJ
+-----END PRIVATE KEY-----
+`

--- a/tests/e2e/fixtures/authenticatedTest.ts
+++ b/tests/e2e/fixtures/authenticatedTest.ts
@@ -1,0 +1,49 @@
+import { importPKCS8, SignJWT } from 'jose'
+
+import { JWT_COOKIE_NAME, SITE_NAME } from '#src/node/static'
+import { JWT_ALGORITHM } from '#src/shared/utils/constants'
+import {
+  TESTING_ACCOUNT_ROW_ID,
+  TESTING_ACCOUNT_USERNAME,
+  TESTING_JWT_PRIVATE_KEY,
+} from '#src/shared/utils/testing'
+import { SITE_URL } from '#tests/e2e/utils/constants'
+
+import { appTest } from './appTest'
+
+const signTestingAccountJwt = async () => {
+  const privateKey = await importPKCS8(TESTING_JWT_PRIVATE_KEY, JWT_ALGORITHM)
+
+  return await new SignJWT({
+    attendances: [],
+    guests: [],
+    role: `${SITE_NAME}_account`,
+    username: TESTING_ACCOUNT_USERNAME,
+  })
+    .setProtectedHeader({ alg: JWT_ALGORITHM })
+    .setSubject(TESTING_ACCOUNT_ROW_ID)
+    .setIssuer('postgraphile')
+    .setAudience('postgraphile')
+    .setJti(crypto.randomUUID())
+    .setExpirationTime('1h')
+    .sign(privateKey)
+}
+
+export const authenticatedTest = appTest.extend<{ signedIn: void }>({
+  signedIn: [
+    async ({ context }, use) => {
+      await context.addCookies([
+        {
+          httpOnly: true,
+          name: JWT_COOKIE_NAME,
+          secure: true,
+          url: SITE_URL,
+          value: await signTestingAccountJwt(),
+        },
+      ])
+
+      await use()
+    },
+    { auto: true },
+  ],
+})

--- a/tests/e2e/specs/pages/event/create.spec.ts
+++ b/tests/e2e/specs/pages/event/create.spec.ts
@@ -1,5 +1,55 @@
+import { expect } from '@playwright/test'
+
+import { authenticatedTest } from '#tests/e2e/fixtures/authenticatedTest'
 import { testVisualRegression } from '#tests/e2e/utils/tests'
 
 const PAGE_PATH = '/event/create'
 
 testVisualRegression(PAGE_PATH)
+
+authenticatedTest.describe('date and time picker', () => {
+  authenticatedTest(
+    'selects a start date and time',
+    async ({ defaultPage }, testInfo) => {
+      // Mobile layout is already covered by the visual regression test above;
+      // on the short Mobile Chrome viewport, the popover's own internal
+      // scroll container doesn't consistently respond to
+      // `scrollIntoViewIfNeeded`, so this interaction test only needs to run
+      // on desktop to verify the picker's behavior.
+      authenticatedTest.skip(testInfo.project.name !== 'chromium')
+
+      await defaultPage.goto(PAGE_PATH)
+
+      const { page } = defaultPage
+      const startTrigger = page.getByRole('button', {
+        exact: true,
+        name: 'Start',
+      })
+      const initialLabel = await startTrigger.innerText()
+
+      await startTrigger.click()
+
+      const todayCell = page.locator('[data-today]')
+      await todayCell.scrollIntoViewIfNeeded()
+      await todayCell.click()
+      await page.keyboard.press('ArrowRight')
+      await page.keyboard.press('Enter')
+
+      const hourSegment = page.locator('[data-reka-time-field-segment="hour"]')
+      await hourSegment.scrollIntoViewIfNeeded()
+      await hourSegment.click()
+      await page.keyboard.press('ArrowUp')
+
+      const minuteSegment = page.locator(
+        '[data-reka-time-field-segment="minute"]',
+      )
+      await minuteSegment.scrollIntoViewIfNeeded()
+      await minuteSegment.click()
+      await page.keyboard.press('ArrowUp')
+
+      await page.keyboard.press('Escape')
+
+      await expect(startTrigger).not.toHaveText(initialLabel)
+    },
+  )
+})

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
     "eslint": "10.8.0",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.6",
+    "jose": "6.2.7",
     "typescript": "6.0.3",
     "typescript-eslint": "8.65.0",
     "ufo": "1.6.4",


### PR DESCRIPTION
Replaces the `v-calendar` `DatePicker` in the event form with an inline `Popover` + `Calendar` + a new `AppTimeField` component built on shadcn-vue/reka-ui primitives, removing the `v-calendar` dependency entirely. The start/end fields now live directly in the form instead of behind a modal with a read-only text input.

`AppTimeField`/`AppTimeFieldSegment` is a hand-built wrapper around reka-ui's `TimeFieldRoot`, since shadcn-vue has no official time-field primitive. It lives under `app/` rather than `scn/` to avoid a shadcn-nuxt component name-resolution bug discovered along the way: a new `TimeField`/`TimeInput` tag silently resolved to the unrelated existing `Field`/`Input` components instead, with no warning in production builds.

Also fixes a mobile viewport overflow in the date/time popover (no scroll container previously), and extends e2e testing support: a test-only JWT keypair with an `isTesting`-gated bypass in `getJwtPublicKey` so Playwright can sign in as a mock account, an `authenticatedTest` fixture, additional GraphQL mock query cases for event categories/formats, and a new interactive spec covering the date/time picker.