### PR TITLE
fix(account): clarify message for already-used verification links

### DIFF
--- a/src/app/pages/account/verify/index.vue
+++ b/src/app/pages/account/verify/index.vue
@@ -1,7 +1,29 @@
+<template>
+  <div v-if="codeIsUnknown" class="flex flex-1 flex-col">
+    <LayoutTopBar>
+      <span>{{ title }}</span>
+    </LayoutTopBar>
+    <LayoutPage>
+      <LayoutPageResult type="warning">
+        <template #description>
+          {{ t('postgresP0002') }}
+        </template>
+      </LayoutPageResult>
+      <template #bottom>
+        <ButtonList>
+          <ButtonSignIn />
+          <ButtonHome />
+        </ButtonList>
+      </template>
+    </LayoutPage>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { useMutation } from '@urql/vue'
 
 import { graphql } from '~~/gql/generated'
+import type { AppCombinedError } from '#shared/types/api'
 
 // compiler
 defineRouteRules({
@@ -41,13 +63,21 @@ const accountEmailAddressVerificationMutation = useMutation(
 const result = await accountEmailAddressVerificationMutation.executeMutation({
   input: { code: route.query.code },
 })
-if (!getResultData(result)) {
+
+// an unknown code is indistinguishable from one that was already consumed by
+// a previous verification, so this case gets a dedicated, less alarming
+// result instead of the generic error page
+const combinedError: AppCombinedError | undefined = result.error
+const codeIsUnknown = combinedError?.graphQLErrors.some(
+  (graphqlError) => graphqlError.errcode === 'P0002',
+)
+
+if (!getResultData(result) && !codeIsUnknown) {
   throw createA11yError({
     data: {
       vibetype: result.error
         ? getCombinedErrorMessages([result.error], {
             postgres55000: t('postgres55000'),
-            postgresP0002: t('postgresP0002'),
           }).join('\n')
         : t('globalErrorNoData'),
     },
@@ -56,18 +86,20 @@ if (!getResultData(result)) {
 }
 
 const localePath = useLocalePath()
-await navigateTo(
-  localePath({ name: 'session-create', query: { verified: null } }),
-)
+if (!codeIsUnknown) {
+  await navigateTo(
+    localePath({ name: 'session-create', query: { verified: null } }),
+  )
+}
 </script>
 
 <i18n lang="yaml">
 de:
   postgres55000: Der Verifizierungscode ist abgelaufen!
-  postgresP0002: Unbekannter Verifizierungscode! Hast du deine E-Mail-Adresse vielleicht schon verifiziert?
+  postgresP0002: Dieser Verifizierungslink ist nicht mehr gültig. Falls du deine E-Mail-Adresse bereits verifiziert hast, ist alles in Ordnung. Melde dich einfach an. Andernfalls fordere einen neuen Verifizierungslink an.
   title: Verifizierung
 en:
   postgres55000: The verification code has expired!
-  postgresP0002: Invalid verification code! Have you perhaps already verified your email address?
+  postgresP0002: This verification link isn't valid anymore. If you already verified your email address, you're all set. Just sign in. Otherwise, request a new verification link.
   title: Verification
 </i18n>

--- a/src/app/pages/account/verify/index.vue
+++ b/src/app/pages/account/verify/index.vue
@@ -96,10 +96,10 @@ if (!codeIsUnknown) {
 <i18n lang="yaml">
 de:
   postgres55000: Der Verifizierungscode ist abgelaufen!
-  postgresP0002: Dieser Verifizierungslink ist nicht mehr gültig. Falls du deine E-Mail-Adresse bereits verifiziert hast, ist alles in Ordnung. Melde dich einfach an. Andernfalls fordere einen neuen Verifizierungslink an.
+  postgresP0002: Dieser Verifizierungslink ist ungültig. Falls du deine E-Mail-Adresse bereits verifiziert hast, ist alles in Ordnung. Melde dich einfach an. Andernfalls fordere einen neuen Verifizierungslink an.
   title: Verifizierung
 en:
   postgres55000: The verification code has expired!
-  postgresP0002: This verification link isn't valid anymore. If you already verified your email address, you're all set. Just sign in. Otherwise, request a new verification link.
+  postgresP0002: This verification link is invalid. If you already verified your email address, you're all set. Just sign in. Otherwise, request a new verification link.
   title: Verification
 </i18n>


### PR DESCRIPTION
Closes #2269.

When someone clicks an email verification link a second time, the backend can't distinguish "already verified" from "genuinely invalid code" (both return the same P0002 error), so the app sent them to the generic, alarming error page with a hedged "have you perhaps already verified?" message.

This shows a dedicated, warning-styled result instead, with clearer copy and a direct "sign in" button, since that's the most likely next step for someone in this state.