### PR TITLE
fix(contact): enforce phone number format validation

### DIFF
--- a/src/app/components/form/FormContact.vue
+++ b/src/app/components/form/FormContact.vue
@@ -176,16 +176,10 @@
               "
             />
           </FieldContent>
-          <p
-            v-if="
-              field.state.meta.isTouched &&
-              field.state.value &&
-              !REGEX_PHONE_NUMBER.test(field.state.value)
-            "
-            class="text-muted-foreground text-sm"
-          >
-            {{ t('phoneNumberFormat') }}
-          </p>
+          <FieldError
+            v-if="isFieldInvalid(field)"
+            :errors="field.state.meta.errors"
+          />
         </Field>
       </form.Field>
       <form.Field v-slot="{ field }" name="url">
@@ -415,7 +409,6 @@ de:
   nickname: Spitzname
   note: Notiz
   phoneNumber: Telefonnummer
-  phoneNumberFormat: Sollte mit einem Plus beginnen, wonach nur Ziffern folgen (z.B. +1234567890)
   postgres23505: Ein Kontakt mit dieser Nutzernamen existiert bereits!
   save: Speichern
   stateInfoUsernameDisabled: Du kannst deinen Nutzernamen in den {accountSettings} ändern.
@@ -431,7 +424,6 @@ en:
   nickname: Nickname
   note: Note
   phoneNumber: Phone number
-  phoneNumberFormat: Should start with a plus followed only by digits (e.g. +1234567890)
   postgres23505: A contact with this username already exists!
   save: Save
   stateInfoUsernameDisabled: You can edit your username in {accountSettings}.

--- a/src/app/utils/validation.ts
+++ b/src/app/utils/validation.ts
@@ -18,6 +18,7 @@ export const VALIDATION_NOTE_LENGTH_MAXIMUM = 1000
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM = 8
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM_V2 = 12
 export const VALIDATION_PASSWORD_SCHEMA = /[!@#$%^&*(),.?":{}|<>]/
+export const VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM = 30 // longest string matching `REGEX_PHONE_NUMBER`
 export const VALIDATION_URL_LENGTH_MAXIMUM = 2000
 export const VALIDATION_USERNAME_LENGTH_MAXIMUM = 100
 
@@ -73,7 +74,11 @@ export const SCHEMA_PASSWORD_V2 = z
   .min(VALIDATION_PASSWORD_LENGTH_MINIMUM_V2)
   .regex(/[A-Z]/)
   .regex(VALIDATION_PASSWORD_SCHEMA)
-export const SCHEMA_PHONE_NUMBER_OPTIONAL = z.string().or(z.literal(''))
+export const SCHEMA_PHONE_NUMBER_OPTIONAL = z
+  .string()
+  .regex(REGEX_PHONE_NUMBER)
+  .max(VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM)
+  .or(z.literal(''))
 export const SCHEMA_URL_HTTPS_OPTIONAL = z
   .string()
   .regex(REGEX_URL_HTTPS)


### PR DESCRIPTION
The phone number field's zod schema (`SCHEMA_PHONE_NUMBER_OPTIONAL`) accepted any string, so the existing `REGEX_PHONE_NUMBER` format hint was purely cosmetic and never blocked invalid input from being saved. This applies the regex and a max length to the schema, matching how the other optional fields (e.g. `SCHEMA_URL_HTTPS_OPTIONAL`) are validated, and switches the field to the standard `FieldError` component used by its siblings. The now-redundant `phoneNumberFormat` hint text/translations are removed.