### PR TITLE
feat(contact): validate and format phone numbers with libphonenumber-js

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,6 +503,9 @@ importers:
       leaflet-control-geocoder:
         specifier: 4.0.0
         version: 4.0.0(leaflet@1.9.4)
+      libphonenumber-js:
+        specifier: 1.13.10
+        version: 1.13.10
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -9024,6 +9027,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libphonenumber-js@1.13.10:
+    resolution: {integrity: sha512-xJxrdqvbl2rtn2MaUJrUejz8J7/uZNC0V77oks2LxYrO/+ZtVpRmz+fEQMuu6VusnEB1fmpByiLS1WXecOnAnw==}
 
   lighthouse-logger@2.0.2:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
@@ -22528,6 +22534,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libphonenumber-js@1.13.10: {}
 
   lighthouse-logger@2.0.2(supports-color@10.2.2):
     dependencies:

--- a/src/app/components/contact/ContactListItem.vue
+++ b/src/app/components/contact/ContactListItem.vue
@@ -16,7 +16,7 @@
       {{ (contact.address || '').replace(/\n/g, ', ') || '–' }}
     </LayoutTd> -->
     <LayoutTd class="hidden xl:table-cell">
-      {{ contact.phoneNumber || '–' }}
+      {{ getPhoneNumberFormatted(contact.phoneNumber) || '–' }}
     </LayoutTd>
     <LayoutTd class="hidden xl:table-cell">
       {{ contact.url || '–' }}

--- a/src/app/components/form/FormContact.vue
+++ b/src/app/components/form/FormContact.vue
@@ -170,7 +170,12 @@
               :model-value="field.state.value"
               :placeholder="t('globalPlaceholderPhoneNumber')"
               type="tel"
-              @blur="field.handleBlur"
+              @blur="
+                () => {
+                  field.handleBlur()
+                  field.handleChange(getPhoneNumberFormatted(field.state.value))
+                }
+              "
               @input="
                 field.handleChange(($event.target as HTMLInputElement).value)
               "

--- a/src/app/utils/validation.ts
+++ b/src/app/utils/validation.ts
@@ -1,6 +1,7 @@
 import type { Client } from '@urql/core'
 import type { Ref } from 'vue'
 
+import { isValidPhoneNumber } from 'libphonenumber-js/min'
 import { z } from 'zod'
 
 import { graphql } from '~~/gql/generated'
@@ -18,7 +19,7 @@ export const VALIDATION_NOTE_LENGTH_MAXIMUM = 1000
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM = 8
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM_V2 = 12
 export const VALIDATION_PASSWORD_SCHEMA = /[!@#$%^&*(),.?":{}|<>]/
-export const VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM = 30 // longest string matching `REGEX_PHONE_NUMBER`
+export const VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM = 30 // generous cap; a valid E.164 number is at most 16 characters
 export const VALIDATION_URL_LENGTH_MAXIMUM = 2000
 export const VALIDATION_USERNAME_LENGTH_MAXIMUM = 100
 
@@ -76,8 +77,8 @@ export const SCHEMA_PASSWORD_V2 = z
   .regex(VALIDATION_PASSWORD_SCHEMA)
 export const SCHEMA_PHONE_NUMBER_OPTIONAL = z
   .string()
-  .regex(REGEX_PHONE_NUMBER)
   .max(VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM)
+  .refine((value) => isValidPhoneNumber(value))
   .or(z.literal(''))
 export const SCHEMA_URL_HTTPS_OPTIONAL = z
   .string()

--- a/src/app/utils/validation.ts
+++ b/src/app/utils/validation.ts
@@ -19,7 +19,7 @@ export const VALIDATION_NOTE_LENGTH_MAXIMUM = 1000
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM = 8
 export const VALIDATION_PASSWORD_LENGTH_MINIMUM_V2 = 12
 export const VALIDATION_PASSWORD_SCHEMA = /[!@#$%^&*(),.?":{}|<>]/
-export const VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM = 30 // generous cap; a valid E.164 number is at most 16 characters
+export const VALIDATION_PHONE_NUMBER_LENGTH_MAXIMUM = 30 // rejects pathological input before parsing; real formatted numbers stay well under this
 export const VALIDATION_URL_LENGTH_MAXIMUM = 2000
 export const VALIDATION_USERNAME_LENGTH_MAXIMUM = 100
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -9,7 +9,7 @@
   "globalPlaceholderAddress": "Veranstaltungsstraße 1,\n12345 Gaststadt",
   "globalPlaceholderFirstName": "Vorname",
   "globalPlaceholderLastName": "Nachname",
-  "globalPlaceholderPhoneNumber": "+1234567890",
+  "globalPlaceholderPhoneNumber": "+12345678901",
   "globalPlaceholderUrl": "https://websei.te",
   "globalSeoOgImageAlt": "@.upper:{'globalSiteName'}s Logo.",
   "globalShowMore": "Mehr anzeigen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -9,7 +9,7 @@
   "globalPlaceholderAddress": "Eventstreet 1,\n12345 Guestcity",
   "globalPlaceholderFirstName": "Firstname",
   "globalPlaceholderLastName": "Lastname",
-  "globalPlaceholderPhoneNumber": "+1234567890",
+  "globalPlaceholderPhoneNumber": "+12345678901",
   "globalPlaceholderUrl": "https://websi.te",
   "globalSeoOgImageAlt": "@.upper:{'globalSiteName'}'s logo.",
   "globalShowMore": "Show more",

--- a/src/package.json
+++ b/src/package.json
@@ -99,6 +99,7 @@
     "kafkajs": "2.2.4",
     "leaflet": "1.9.4",
     "leaflet-control-geocoder": "4.0.0",
+    "libphonenumber-js": "1.13.10",
     "lodash-es": "4.18.1",
     "mustache": "4.2.0",
     "nodemailer": "9.0.3",

--- a/src/shared/utils/constants.ts
+++ b/src/shared/utils/constants.ts
@@ -28,7 +28,6 @@ export type LOCALE_CODES = 'de' | 'en'
 export const MAEVSI_EMAIL_RATE_LIMIT_PER_DAY = 150
 export const MAEVSI_EMAIL_RATE_LIMIT_PER_SECOND = 14
 export const POSTGRES_INTEGER_MAXIMUM = Math.pow(2, 31) - 1
-export const REGEX_PHONE_NUMBER = /^\+(?:[0-9] ?){6,14}[0-9]$/
 export const REGEX_SLUG = /^[-A-Za-z0-9]+$/
 export const REGEX_UPPERCASE_NONE = /^[^A-Z]+$/
 export const REGEX_URL_HTTPS = /^https:\/\//

--- a/src/shared/utils/phoneNumber.ts
+++ b/src/shared/utils/phoneNumber.ts
@@ -1,0 +1,13 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js/min'
+
+export const getPhoneNumberFormatted = <T extends string | null | undefined>(
+  phoneNumber: T,
+): T | string => {
+  if (!phoneNumber) return phoneNumber
+
+  const parsedPhoneNumber = parsePhoneNumberFromString(phoneNumber)
+
+  return parsedPhoneNumber?.isValid()
+    ? parsedPhoneNumber.formatInternational()
+    : phoneNumber
+}


### PR DESCRIPTION
Adds `libphonenumber-js` and replaces the loose regex-based phone number check with real E.164 validation (`isValidPhoneNumber`). The field is also normalized to a nicely formatted international representation on blur, and contact list display now formats stored numbers the same way instead of showing the raw string.

Closes #1384.