### PR TITLE
fix(email): attach ical event to outgoing mails

### DIFF
--- a/src/server/utils/email.ts
+++ b/src/server/utils/email.ts
@@ -98,6 +98,7 @@ export const sendEmail = async <T extends EmailName>({
     subject: mailOptions.subject,
     text,
     html,
+    ...(mailOptions.icalEvent ? { icalEvent: mailOptions.icalEvent } : {}),
     list: {
       // TODO: add https link (https://github.com/maevsi/vibetype/issues/326)
       unsubscribe: `mailto:contact+unsubscribe@maev.si?subject=Unsubscribe%20${mailOptions.to}`,


### PR DESCRIPTION
Invitation emails were fetching the `.ics` calendar data and passing it as `icalEvent`, but `sendEmail` never included that field in the object handed to `transporter.sendMail`, so nodemailer silently dropped it and no calendar attachment was ever sent.