### PR TITLE
fix(form): prevent accidental enter-key submissions

### DIFF
--- a/src/app/components/form/FormDelete.vue
+++ b/src/app/components/form/FormDelete.vue
@@ -13,6 +13,7 @@
               :model-value="field.state.value"
               @blur="field.handleBlur"
               @input="field.handleChange($event)"
+              @keydown.enter.prevent
             />
           </FieldContent>
           <FieldError

--- a/src/app/components/form/FormGuest.vue
+++ b/src/app/components/form/FormGuest.vue
@@ -1,10 +1,5 @@
 <template>
-  <form
-    v-if="event"
-    class="flex min-h-0 flex-col"
-    novalidate
-    @submit.prevent="form.handleSubmit"
-  >
+  <div v-if="event" class="flex min-h-0 flex-col">
     <div class="flex flex-col gap-4">
       <div class="flex flex-col items-center gap-4">
         <span>
@@ -20,75 +15,72 @@
           </template>
         </ButtonColored>
       </div>
-      <form.Field v-slot="{ field }" name="searchString">
-        <Field>
-          <FieldLabel for="input-contact-id">{{ t('contact') }}</FieldLabel>
-          <FieldContent>
-            <div class="relative">
-              <AppIconMagnifyingGlass
-                class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2"
-              />
-              <Input
-                id="input-contact-id"
-                class="pl-9"
-                :model-value="field.state.value"
-                :placeholder="t('placeholderContact')"
-                type="text"
-                @blur="field.handleBlur"
-                @input="
-                  field.handleChange(($event.target as HTMLInputElement).value)
+      <Field>
+        <FieldLabel for="input-contact-id">{{ t('contact') }}</FieldLabel>
+        <FieldContent>
+          <div class="relative">
+            <AppIconMagnifyingGlass
+              class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2"
+            />
+            <Input
+              id="input-contact-id"
+              class="pl-9"
+              :model-value="searchString"
+              :placeholder="t('placeholderContact')"
+              type="text"
+              @input="searchString = ($event.target as HTMLInputElement).value"
+            />
+          </div>
+        </FieldContent>
+      </Field>
+      <form class="contents" novalidate @submit.prevent="form.handleSubmit">
+        <form.Field v-slot="{ field }" name="contactIds">
+          <FieldError
+            v-if="isFieldInvalid(field)"
+            :errors="field.state.meta.errors"
+          />
+          <AppScrollContainer
+            v-if="contacts"
+            class="flex flex-col gap-2"
+            :has-next-page="!!apiData.data.allContacts?.pageInfo.hasNextPage"
+            @load-more="after = apiData.data.allContacts?.pageInfo.endCursor"
+          >
+            <AppButton
+              v-for="contact in contactsFiltered"
+              :key="contact.rowId"
+              :aria-label="t('buttonContact')"
+              class="flex w-full items-center gap-4 rounded-sm border-2 border-neutral-300 px-4 py-2 dark:border-neutral-600"
+              :disabled="guestContactIdsExisting?.includes(contact.rowId)"
+              type="button"
+              @click="selectToggle(contact.rowId, field)"
+            >
+              <ContactPreview :contact :is-username-linked="false" />
+              <FormCheckbox
+                :is-disabled="guestContactIdsExisting?.includes(contact.rowId)"
+                :value="
+                  guestContactIdsExisting?.includes(contact.rowId) ||
+                  field.state.value.includes(contact.rowId)
                 "
               />
-            </div>
-          </FieldContent>
-        </Field>
-      </form.Field>
-      <form.Field v-slot="{ field }" name="contactIds">
-        <FieldError
-          v-if="isFieldInvalid(field)"
-          :errors="field.state.meta.errors"
-        />
-        <AppScrollContainer
-          v-if="contacts"
-          class="flex flex-col gap-2"
-          :has-next-page="!!apiData.data.allContacts?.pageInfo.hasNextPage"
-          @load-more="after = apiData.data.allContacts?.pageInfo.endCursor"
-        >
-          <AppButton
-            v-for="contact in contactsFiltered"
-            :key="contact.rowId"
-            :aria-label="t('buttonContact')"
-            class="flex w-full items-center gap-4 rounded-sm border-2 border-neutral-300 px-4 py-2 dark:border-neutral-600"
-            :disabled="guestContactIdsExisting?.includes(contact.rowId)"
-            type="button"
-            @click="selectToggle(contact.rowId, field)"
+            </AppButton>
+          </AppScrollContainer>
+        </form.Field>
+        <div class="flex flex-col items-center">
+          <ButtonColored
+            :aria-label="t('select')"
+            class="w-full"
+            :loading="createGuestsMutation.fetching.value"
+            type="submit"
           >
-            <ContactPreview :contact :is-username-linked="false" />
-            <FormCheckbox
-              :is-disabled="guestContactIdsExisting?.includes(contact.rowId)"
-              :value="
-                guestContactIdsExisting?.includes(contact.rowId) ||
-                field.state.value.includes(contact.rowId)
-              "
-            />
-          </AppButton>
-        </AppScrollContainer>
-      </form.Field>
-      <div class="flex flex-col items-center">
-        <ButtonColored
-          :aria-label="t('select')"
-          class="w-full"
-          :loading="createGuestsMutation.fetching.value"
-          type="submit"
-        >
-          {{ t('select') }}
-        </ButtonColored>
-      </div>
-      <CardStateAlert v-if="errorMessages?.length">
-        <AppSpanList :span="errorMessages" />
-      </CardStateAlert>
+            {{ t('select') }}
+          </ButtonColored>
+        </div>
+        <CardStateAlert v-if="errorMessages?.length">
+          <AppSpanList :span="errorMessages" />
+        </CardStateAlert>
+      </form>
     </div>
-  </form>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -168,15 +160,15 @@ const contacts = computed(
 )
 
 // form
+const searchString = ref('')
+
 const formSchema = z.object({
   contactIds: z.array(z.string()).min(1),
-  searchString: z.string(),
 })
 
 const form = useForm({
   defaultValues: {
     contactIds: [] as string[],
-    searchString: '',
   },
   validators: {
     onSubmit: formSchema,
@@ -227,7 +219,6 @@ const selectToggle = (contactId: string, field: AnyFieldApi) => {
 }
 
 // computations
-const searchString = computed(() => form.getFieldValue('searchString'))
 const contactsFiltered = computed(() => {
   if (!contacts.value) {
     return undefined

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -13,7 +13,11 @@
     <!-- Step: Email -->
     <AppStep v-slot="attributes" :is-active="step === 'default'">
       <LayoutPage v-bind="attributes">
-        <div class="flex flex-col gap-6">
+        <form
+          class="flex flex-col gap-6"
+          novalidate
+          @submit.prevent="handleEmailContinue"
+        >
           <FormAuthInput
             :aria-label="t('emailPlaceholder')"
             :model-value="emailField.value.value"
@@ -59,10 +63,7 @@
           <p v-if="termsError" class="text-sm text-red-600">
             {{ termsError }}
           </p>
-          <FormAuthButton
-            :aria-label="t('continue')"
-            @click="handleEmailContinue"
-          >
+          <FormAuthButton :aria-label="t('continue')" type="submit">
             {{ t('continue') }}
           </FormAuthButton>
           <p class="text-center text-[15px] text-gray-500 dark:text-gray-400">
@@ -73,7 +74,7 @@
               >{{ t('signInLink') }}</NuxtLinkLocale
             >
           </p>
-        </div>
+        </form>
       </LayoutPage>
     </AppStep>
 
@@ -95,7 +96,11 @@
     <!-- Step: Username -->
     <AppStep v-slot="attributes" :is-active="step === 'username'">
       <LayoutPage v-bind="attributes">
-        <div class="flex flex-col gap-4">
+        <form
+          class="flex flex-col gap-4"
+          novalidate
+          @submit.prevent="handleUsernameContinue"
+        >
           <div class="relative">
             <FormAuthInput
               :aria-label="t('usernamePlaceholder')"
@@ -127,11 +132,11 @@
             :disabled="
               !usernameField.value.value || !!usernameField.error.value
             "
-            @click="handleUsernameContinue"
+            type="submit"
           >
             {{ t('continue') }}
           </FormAuthButton>
-        </div>
+        </form>
       </LayoutPage>
     </AppStep>
 


### PR DESCRIPTION
Block enter key from submitting the password-gated delete confirmation, since a stray keystroke can trigger an irreversible deletion.
Move the guest search field outside the submittable form so filtering contacts can no longer accidentally send invitations.
Wrap the email and username registration steps in a form so the enter key submits them like the rest of the app, instead of doing nothing.