### PR TITLE
fix(email): correct ical payload field names for event invitations

### DIFF
--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -26,7 +26,7 @@ type Template = {
 }
 
 type Event = {
-  id: number
+  id: string
   createdBy: string
   description: string | null
   end: string | null // Date
@@ -367,17 +367,21 @@ export const sendEventInvitationMail = async ({
   const icalFetch = await fetch(
     `http://${SITE_NAME}:3000/api/model/event/ical`,
     {
+      // `contact` is intentionally omitted here: this notification's payload only carries
+      // `emailAddress`/`timeZone`, not the guest's linked `Contact` record (`firstName`/`lastName`),
+      // so `{{contact.firstName}}`-style merge fields in the event description render blank in the
+      // emailed `.ics` attachment, unlike the guest-view page's manual download.
       body: JSON.stringify({
-        contact: { emailAddress },
         event: {
           ...event,
           accountByCreatedBy: {
             username: eventCreatorUsername,
           },
+          rowId: event.id,
           visibility: event.visibility,
         },
         guest: {
-          id: guestId,
+          rowId: guestId,
         },
       }),
       method: 'POST',


### PR DESCRIPTION
The `/api/model/event/ical` endpoint's schema expects `event.rowId`, `guest.rowId`, and `contact.firstName`/`contact.lastName`, but `sendEventInvitationMail` sent `event.id`, `guest.id`, and `contact.emailAddress` — a naming mismatch that made every request fail validation, so ical attachments never made it into outgoing invitation mails even after #2361 wired up the attachment step.

Also fixes a stale `Event.id: number` type; the trigger payload actually carries a UUID string there, and it's already used as a string elsewhere in this file (`guestId`).