### PR TITLE
feat(account): send registration and password reset emails in the recipient's time zone

### DIFF
--- a/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordResetRequest.vue
@@ -124,6 +124,7 @@ const form = useForm({
       input: {
         emailAddress: value.emailAddress,
         language: locale.value,
+        timeZone: useTimeZone(),
       },
     })
 

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -351,6 +351,7 @@ const submit = async () => {
         language: locale.value,
         legalTermId: legalTermIdValue,
         password: passwordData.value.password,
+        timeZone: useTimeZone(),
         username: usernameField.value.value,
       },
     },

--- a/src/gql/generated/graphcache.ts
+++ b/src/gql/generated/graphcache.ts
@@ -664,6 +664,7 @@ export type AccountPasswordResetRequestInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>
   emailAddress: Scalars['String']['input']
   language: Scalars['String']['input']
+  timeZone?: InputMaybe<Scalars['String']['input']>
 }
 
 /** The output of our `accountPasswordResetRequest` mutation. */
@@ -698,6 +699,7 @@ export type AccountRegistrationInput = {
   language: Scalars['String']['input']
   legalTermId: Scalars['UUID']['input']
   password: Scalars['String']['input']
+  timeZone?: InputMaybe<Scalars['String']['input']>
   username: Scalars['String']['input']
 }
 

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -68,6 +68,7 @@ export type AccountPasswordResetRequestInput = {
   clientMutationId?: string | null | undefined
   emailAddress: string
   language: string
+  timeZone?: string | null | undefined
 }
 
 /** Represents an update to a `Account`. Fields that are set will be updated. */
@@ -90,6 +91,7 @@ export type AccountRegistrationInput = {
   language: string
   legalTermId: string
   password: string
+  timeZone?: string | null | undefined
   username: string
 }
 

--- a/src/server/api/test/service/vibetype/email.get.ts
+++ b/src/server/api/test/service/vibetype/email.get.ts
@@ -16,6 +16,7 @@ const getDemoEmailProps = (locale: AppLocale) =>
       passwordResetVerificationLink:
         'https://example.com/reset-password?token=abcd1234',
       stackDomain: 'example.com',
+      timeZone: 'Europe/Berlin',
       username: 'john_doe',
       validUntil: '2024-12-31T23:59:59Z',
     },
@@ -26,6 +27,7 @@ const getDemoEmailProps = (locale: AppLocale) =>
       locale,
       logoSource,
       stackDomain: 'example.com',
+      timeZone: 'Europe/Berlin',
       username: 'john_doe',
       validUntil: '2024-12-31T23:59:59Z',
     },

--- a/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
+++ b/src/server/assets/emails/EmailAccountPasswordResetRequest.vue
@@ -12,16 +12,18 @@ const {
   locale,
   logoSource = undefined,
   passwordResetVerificationLink,
+  timeZone = undefined,
   validUntil,
 } = defineProps<{
   emailAddress: string
   locale: AppLocale
   logoSource?: string
   passwordResetVerificationLink: string
+  timeZone?: string
   validUntil: string
 }>()
 
-const dateTimeFormatter = getEmailDateTimeFormatter(locale)
+const dateTimeFormatter = getEmailDateTimeFormatter(locale, timeZone)
 const locales = {
   de: {
     button: 'Passwort zurücksetzen',

--- a/src/server/assets/emails/EmailAccountRegistration.vue
+++ b/src/server/assets/emails/EmailAccountRegistration.vue
@@ -12,6 +12,7 @@ const {
   emailAddressVerificationLink,
   locale,
   logoSource = undefined,
+  timeZone = undefined,
   username,
   validUntil,
 } = defineProps<{
@@ -19,11 +20,12 @@ const {
   emailAddressVerificationLink: string
   locale: AppLocale
   logoSource?: string
+  timeZone?: string
   username: string
   validUntil: string
 }>()
 
-const dateTimeFormatter = getEmailDateTimeFormatter(locale)
+const dateTimeFormatter = getEmailDateTimeFormatter(locale, timeZone)
 const locales = {
   de: {
     button: 'Registrierung abschließen',

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -22,6 +22,7 @@ export type Account = {
 type Template = {
   language: AppLocale
   namespace: string
+  time_zone?: string | null
   variables: Record<string, unknown>
 }
 
@@ -194,6 +195,7 @@ export const processNotification = async ({
           }/account/password/reset?code=${
             payload.account.password_reset_verification
           }`,
+          timeZone: payload.template.time_zone ?? undefined,
           validUntil: payload.account.password_reset_verification_valid_until,
         },
         rateLimitPerDay,
@@ -216,6 +218,7 @@ export const processNotification = async ({
               : ''
           }/account/verify?code=${payload.account.email_address_verification}`,
           locale,
+          timeZone: payload.template.time_zone ?? undefined,
           username: payload.account.username,
           validUntil: payload.account.email_address_verification_valid_until,
         },


### PR DESCRIPTION
Threads the browser-detected time zone (`useTimeZone()`) through the account registration and password reset request mutations so their emails render the `validUntil` date in the recipient's local time instead of always UTC, matching how event invitation emails already behave. Resolves #2354.

Depends on maevsi/sqitch#322 and maevsi/sqitch#323 for the new `timeZone` input field on both mutations.