### PR TITLE
feat: add deletion confirmation drawers

### DIFF
--- a/src/app/components/account/AccountProfilePictureRemoveDrawer.vue
+++ b/src/app/components/account/AccountProfilePictureRemoveDrawer.vue
@@ -1,65 +1,16 @@
 <template>
-  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
-    <AppStep v-slot="attributes" :is-active="step === 'default'">
-      <div v-bind="attributes" class="text-center">
-        <TypographySubtitleSmall>
-          {{ t('profilePictureRemoveQuestion') }}
-        </TypographySubtitleSmall>
-      </div>
-    </AppStep>
-    <AppStep v-slot="attributes" :is-active="step === 'error'">
-      <div v-bind="attributes">
-        <LayoutPageResult type="error">
-          <template v-if="error" #description>
-            {{ error.message }}
-          </template>
-        </LayoutPageResult>
-      </div>
-    </AppStep>
-    <template #title>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <span v-bind="attributes">
-          {{ t('title') }}
-        </span>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <span v-bind="attributes">
-          {{ t('error') }}
-        </span>
-      </AppStep>
-    </template>
-    <template #footer>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('keepProfilePicture')"
-          variant="secondary"
-          @click="closeDrawer"
-        >
-          {{ t('keepProfilePicture') }}
-        </ButtonColored>
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('profilePictureRemove')"
-          :loading="isPending"
-          variant="primary-critical"
-          @click="removeProfilePicture"
-        >
-          {{ t('profilePictureRemove') }}
-        </ButtonColored>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('restart')"
-          variant="tertiary"
-          @click="restart"
-        >
-          {{ t('restart') }}
-        </ButtonColored>
-      </AppStep>
-    </template>
-  </AppDrawer>
+  <AppConfirmDeleteDrawer
+    v-model:open="isOpen"
+    :cancel-label="t('keepProfilePicture')"
+    :confirm-label="t('profilePictureRemove')"
+    :error
+    :is-pending="isPending"
+    :title="t('title')"
+    @confirm="onConfirm"
+    @restart="restart"
+  >
+    {{ t('profilePictureRemoveQuestion') }}
+  </AppConfirmDeleteDrawer>
 </template>
 
 <script setup lang="ts">
@@ -74,18 +25,7 @@ const emit = defineEmits<{
   success: []
 }>()
 
-const { error, restart, step } = useStepper()
-
-// drawer
 const isOpen = defineModel<boolean>('open')
-const closeDrawer = () => {
-  isOpen.value = false
-}
-const onAnimationEnd = (isOpen: boolean) => {
-  if (isOpen) return
-
-  step.value = 'default'
-}
 
 const deleteProfilePictureByRowIdMutation = useMutation(
   graphql(`
@@ -98,21 +38,21 @@ const deleteProfilePictureByRowIdMutation = useMutation(
     }
   `),
 )
+const { confirm, error, restart } = useMutationConfirmation()
 const isPending = computed(
   () => deleteProfilePictureByRowIdMutation.fetching.value,
 )
 
-const removeProfilePicture = async () => {
-  const result = await deleteProfilePictureByRowIdMutation.executeMutation({
-    input: { rowId: profilePictureRowId },
-  })
+const onConfirm = async () => {
+  const result = await confirm(
+    deleteProfilePictureByRowIdMutation.executeMutation({
+      input: { rowId: profilePictureRowId },
+    }),
+  )
 
-  if (!getResultData(result)) {
-    error.value = result.error ?? new Error(t('globalErrorNoData'))
-    return
-  }
+  if (!result) return
 
-  closeDrawer()
+  isOpen.value = false
   emit('success')
 }
 
@@ -122,17 +62,13 @@ const { t } = useI18n()
 
 <i18n lang="yaml">
 de:
-  error: Fehler
   keepProfilePicture: Nein, behalten
   profilePictureRemove: Bild entfernen
   profilePictureRemoveQuestion: Möchtest du dein Profilbild wirklich entfernen?
-  restart: Erneut versuchen
   title: Profilbild entfernen
 en:
-  error: Error
   keepProfilePicture: No, keep it
   profilePictureRemove: Remove image
   profilePictureRemoveQuestion: Do you really want to remove your profile picture?
-  restart: Try again
   title: Remove profile picture
 </i18n>

--- a/src/app/components/account/AccountProfilePictureRemoveDrawer.vue
+++ b/src/app/components/account/AccountProfilePictureRemoveDrawer.vue
@@ -1,0 +1,138 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          {{ t('profilePictureRemoveQuestion') }}
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <span v-bind="attributes">
+          {{ t('title') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <span v-bind="attributes">
+          {{ t('error') }}
+        </span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('keepProfilePicture')"
+          variant="secondary"
+          @click="closeDrawer"
+        >
+          {{ t('keepProfilePicture') }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('profilePictureRemove')"
+          :loading="isPending"
+          variant="primary-critical"
+          @click="removeProfilePicture"
+        >
+          {{ t('profilePictureRemove') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('restart')"
+          variant="tertiary"
+          @click="restart"
+        >
+          {{ t('restart') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { useMutation } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+
+const { profilePictureRowId } = defineProps<{
+  profilePictureRowId: string
+}>()
+const emit = defineEmits<{
+  success: []
+}>()
+
+const { error, restart, step } = useStepper()
+
+// drawer
+const isOpen = defineModel<boolean>('open')
+const closeDrawer = () => {
+  isOpen.value = false
+}
+const onAnimationEnd = (isOpen: boolean) => {
+  if (isOpen) return
+
+  step.value = 'default'
+}
+
+const deleteProfilePictureByRowIdMutation = useMutation(
+  graphql(`
+    mutation DeleteProfilePictureByRowIdMutation(
+      $input: DeleteProfilePictureByRowIdInput!
+    ) {
+      deleteProfilePictureByRowId(input: $input) {
+        clientMutationId
+      }
+    }
+  `),
+)
+const isPending = computed(
+  () => deleteProfilePictureByRowIdMutation.fetching.value,
+)
+
+const removeProfilePicture = async () => {
+  const result = await deleteProfilePictureByRowIdMutation.executeMutation({
+    input: { rowId: profilePictureRowId },
+  })
+
+  if (!getResultData(result)) {
+    error.value = result.error ?? new Error(t('globalErrorNoData'))
+    return
+  }
+
+  closeDrawer()
+  emit('success')
+}
+
+// template
+const { t } = useI18n()
+</script>
+
+<i18n lang="yaml">
+de:
+  error: Fehler
+  keepProfilePicture: Nein, behalten
+  profilePictureRemove: Bild entfernen
+  profilePictureRemoveQuestion: Möchtest du dein Profilbild wirklich entfernen?
+  restart: Erneut versuchen
+  title: Profilbild entfernen
+en:
+  error: Error
+  keepProfilePicture: No, keep it
+  profilePictureRemove: Remove image
+  profilePictureRemoveQuestion: Do you really want to remove your profile picture?
+  restart: Try again
+  title: Remove profile picture
+</i18n>

--- a/src/app/components/app/AppConfirmDeleteDrawer.vue
+++ b/src/app/components/app/AppConfirmDeleteDrawer.vue
@@ -1,0 +1,82 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="!error">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          <slot />
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="!!error">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="!error">
+        <span v-bind="attributes">{{ title }}</span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="!!error">
+        <span v-bind="attributes">{{ t('globalError') }}</span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="!error">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="cancelLabel"
+          variant="secondary"
+          @click="isOpen = false"
+        >
+          {{ cancelLabel }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="confirmLabel"
+          :loading="isPending"
+          variant="primary-critical"
+          @click="emit('confirm')"
+        >
+          {{ confirmLabel }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="!!error">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('globalTryAgain')"
+          variant="tertiary"
+          @click="emit('restart')"
+        >
+          {{ t('globalTryAgain') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  cancelLabel: string
+  confirmLabel: string
+  error?: Error
+  isPending?: boolean
+  title: string
+}>()
+const emit = defineEmits<{
+  confirm: []
+  restart: []
+}>()
+
+const isOpen = defineModel<boolean>('open')
+const onAnimationEnd = (isOpenValue: boolean) => {
+  if (isOpenValue) return
+
+  emit('restart')
+}
+
+const { t } = useI18n()
+</script>

--- a/src/app/components/contact/ContactDeleteDrawer.vue
+++ b/src/app/components/contact/ContactDeleteDrawer.vue
@@ -1,0 +1,148 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          {{ t('contactDeleteQuestion', { name: contactName }) }}
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <span v-bind="attributes">
+          {{ t('title') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <span v-bind="attributes">
+          {{ t('error') }}
+        </span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('keepContact')"
+          variant="secondary"
+          @click="closeDrawer"
+        >
+          {{ t('keepContact') }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('contactDelete')"
+          :loading="isPending"
+          variant="primary-critical"
+          @click="deleteContact"
+        >
+          {{ t('contactDelete') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('restart')"
+          variant="tertiary"
+          @click="restart"
+        >
+          {{ t('restart') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { useMutation } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+import type { ContactItemFragment } from '~~/gql/generated/graphql'
+import { getContactName } from '~~/shared/utils/model'
+
+const { contact, contactRowId } = defineProps<{
+  contact: Pick<
+    ContactItemFragment,
+    'accountByAccountId' | 'accountId' | 'firstName' | 'lastName' | 'nickname'
+  >
+  contactRowId: string
+}>()
+const emit = defineEmits<{
+  success: []
+}>()
+
+const contactName = computed(
+  () =>
+    getContactName({ account: contact.accountByAccountId, contact }) ||
+    t('contactNameUnknown'),
+)
+
+const { error, restart, step } = useStepper()
+
+// drawer
+const isOpen = defineModel<boolean>('open')
+const closeDrawer = () => {
+  isOpen.value = false
+}
+const onAnimationEnd = (isOpen: boolean) => {
+  if (isOpen) return
+
+  step.value = 'default'
+}
+
+const deleteContactByRowIdMutation = useMutation(
+  graphql(`
+    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {
+      deleteContactByRowId(input: $input) {
+        clientMutationId
+      }
+    }
+  `),
+)
+const isPending = computed(() => deleteContactByRowIdMutation.fetching.value)
+
+const deleteContact = async () => {
+  const result = await deleteContactByRowIdMutation.executeMutation({
+    input: { rowId: contactRowId },
+  })
+
+  if (!getResultData(result)) {
+    error.value = result.error ?? new Error(t('globalErrorNoData'))
+    return
+  }
+
+  closeDrawer()
+  emit('success')
+}
+
+// template
+const { t } = useI18n()
+</script>
+
+<i18n lang="yaml">
+de:
+  contactDelete: Kontakt löschen
+  contactDeleteQuestion: Möchtest du den Kontakt {name} wirklich löschen?
+  contactNameUnknown: einen unbenannten Kontakt
+  error: Fehler
+  keepContact: Nein, behalten
+  restart: Erneut versuchen
+  title: Kontakt löschen
+en:
+  contactDelete: Delete contact
+  contactDeleteQuestion: Do you really want to delete the contact {name}?
+  contactNameUnknown: an unnamed contact
+  error: Error
+  keepContact: No, keep them
+  restart: Try again
+  title: Delete contact
+</i18n>

--- a/src/app/components/contact/ContactDeleteDrawer.vue
+++ b/src/app/components/contact/ContactDeleteDrawer.vue
@@ -1,65 +1,16 @@
 <template>
-  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
-    <AppStep v-slot="attributes" :is-active="step === 'default'">
-      <div v-bind="attributes" class="text-center">
-        <TypographySubtitleSmall>
-          {{ t('contactDeleteQuestion', { name: contactName }) }}
-        </TypographySubtitleSmall>
-      </div>
-    </AppStep>
-    <AppStep v-slot="attributes" :is-active="step === 'error'">
-      <div v-bind="attributes">
-        <LayoutPageResult type="error">
-          <template v-if="error" #description>
-            {{ error.message }}
-          </template>
-        </LayoutPageResult>
-      </div>
-    </AppStep>
-    <template #title>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <span v-bind="attributes">
-          {{ t('title') }}
-        </span>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <span v-bind="attributes">
-          {{ t('error') }}
-        </span>
-      </AppStep>
-    </template>
-    <template #footer>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('keepContact')"
-          variant="secondary"
-          @click="closeDrawer"
-        >
-          {{ t('keepContact') }}
-        </ButtonColored>
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('contactDelete')"
-          :loading="isPending"
-          variant="primary-critical"
-          @click="deleteContact"
-        >
-          {{ t('contactDelete') }}
-        </ButtonColored>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('restart')"
-          variant="tertiary"
-          @click="restart"
-        >
-          {{ t('restart') }}
-        </ButtonColored>
-      </AppStep>
-    </template>
-  </AppDrawer>
+  <AppConfirmDeleteDrawer
+    v-model:open="isOpen"
+    :cancel-label="t('keepContact')"
+    :confirm-label="t('contactDelete')"
+    :error
+    :is-pending="isPending"
+    :title="t('title')"
+    @confirm="onConfirm"
+    @restart="restart"
+  >
+    {{ t('contactDeleteQuestion', { name: contactName }) }}
+  </AppConfirmDeleteDrawer>
 </template>
 
 <script setup lang="ts">
@@ -86,18 +37,7 @@ const contactName = computed(
     t('contactNameUnknown'),
 )
 
-const { error, restart, step } = useStepper()
-
-// drawer
 const isOpen = defineModel<boolean>('open')
-const closeDrawer = () => {
-  isOpen.value = false
-}
-const onAnimationEnd = (isOpen: boolean) => {
-  if (isOpen) return
-
-  step.value = 'default'
-}
 
 const deleteContactByRowIdMutation = useMutation(
   graphql(`
@@ -108,19 +48,19 @@ const deleteContactByRowIdMutation = useMutation(
     }
   `),
 )
+const { confirm, error, restart } = useMutationConfirmation()
 const isPending = computed(() => deleteContactByRowIdMutation.fetching.value)
 
-const deleteContact = async () => {
-  const result = await deleteContactByRowIdMutation.executeMutation({
-    input: { rowId: contactRowId },
-  })
+const onConfirm = async () => {
+  const result = await confirm(
+    deleteContactByRowIdMutation.executeMutation({
+      input: { rowId: contactRowId },
+    }),
+  )
 
-  if (!getResultData(result)) {
-    error.value = result.error ?? new Error(t('globalErrorNoData'))
-    return
-  }
+  if (!result) return
 
-  closeDrawer()
+  isOpen.value = false
   emit('success')
 }
 
@@ -133,16 +73,12 @@ de:
   contactDelete: Kontakt löschen
   contactDeleteQuestion: Möchtest du den Kontakt {name} wirklich löschen?
   contactNameUnknown: einen unbenannten Kontakt
-  error: Fehler
   keepContact: Nein, behalten
-  restart: Erneut versuchen
   title: Kontakt löschen
 en:
   contactDelete: Delete contact
   contactDeleteQuestion: Do you really want to delete the contact {name}?
   contactNameUnknown: an unnamed contact
-  error: Error
   keepContact: No, keep them
-  restart: Try again
   title: Delete contact
 </i18n>

--- a/src/app/components/contact/ContactList.vue
+++ b/src/app/components/contact/ContactList.vue
@@ -34,9 +34,8 @@
               :id="contact.rowId"
               :key="contact.rowId"
               :contact
-              :is-deleting="pending.deletions.includes(contact.rowId)"
               :is-editing="pending.edits.includes(contact.rowId)"
-              @delete="delete_(contact.rowId)"
+              @delete="onDeleteSelect(contact)"
               @edit="edit(contact)"
             />
           </LayoutTbody>
@@ -63,12 +62,18 @@
           {{ formContactHeading }}
         </template>
       </Modal>
+      <ContactDeleteDrawer
+        v-if="contactToDelete"
+        v-model:open="isDeleteDrawerOpen"
+        :contact="contactToDelete"
+        :contact-row-id="contactToDelete.rowId"
+      />
     </div>
   </Loader>
 </template>
 
 <script setup lang="ts">
-import { useMutation, useQuery } from '@urql/vue'
+import { useQuery } from '@urql/vue'
 
 import { graphql } from '~~/gql/generated'
 import type {
@@ -82,10 +87,22 @@ const store = useStore()
 
 // data
 const after = ref<string | null>()
+const contactToDelete =
+  ref<
+    Pick<
+      ContactItemFragment,
+      | 'accountByAccountId'
+      | 'accountId'
+      | 'firstName'
+      | 'lastName'
+      | 'nickname'
+      | 'rowId'
+    >
+  >()
 const formContactHeading = ref<string>()
+const isDeleteDrawerOpen = ref(false)
 const isModalContactOpen = ref<boolean>()
 const pending = reactive({
-  deletions: ref<string[]>([]),
   edits: ref<string[]>([]),
 })
 const selectedContact = ref<
@@ -132,16 +149,7 @@ const contactsQuery = useQuery({
     first: ITEMS_PER_PAGE_LARGE,
   })),
 })
-const deleteContactByRowIdMutation = useMutation(
-  graphql(`
-    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {
-      deleteContactByRowId(input: $input) {
-        clientMutationId
-      }
-    }
-  `),
-)
-const api = await useApiData([contactsQuery, deleteContactByRowIdMutation])
+const api = await useApiData([contactsQuery])
 const contacts = computed(
   () =>
     api.value.data.allContacts?.nodes
@@ -156,10 +164,19 @@ const add = () => {
   selectedContact.value = undefined
   isModalContactOpen.value = true
 }
-const delete_ = async (rowId: string) => {
-  pending.deletions.push(rowId)
-  await deleteContactByRowIdMutation.executeMutation({ input: { rowId } })
-  pending.deletions.splice(pending.deletions.indexOf(rowId), 1)
+const onDeleteSelect = (
+  contact: Pick<
+    ContactItemFragment,
+    | 'accountByAccountId'
+    | 'accountId'
+    | 'firstName'
+    | 'lastName'
+    | 'nickname'
+    | 'rowId'
+  >,
+) => {
+  contactToDelete.value = contact
+  isDeleteDrawerOpen.value = true
   // TODO: update cache, especially pagination, or reset query (https://github.com/maevsi/vibetype/issues/720)
 }
 const edit = (

--- a/src/app/components/guest/GuestDeleteDrawer.vue
+++ b/src/app/components/guest/GuestDeleteDrawer.vue
@@ -1,0 +1,148 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          {{ t('guestDeleteQuestion', { name: contactName }) }}
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <span v-bind="attributes">
+          {{ t('title') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <span v-bind="attributes">
+          {{ t('error') }}
+        </span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('keepGuest')"
+          variant="secondary"
+          @click="closeDrawer"
+        >
+          {{ t('keepGuest') }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('guestDelete')"
+          :loading="isPending"
+          variant="primary-critical"
+          @click="deleteGuest"
+        >
+          {{ t('guestDelete') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('restart')"
+          variant="tertiary"
+          @click="restart"
+        >
+          {{ t('restart') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { useMutation } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+import type { ContactItemFragment } from '~~/gql/generated/graphql'
+import { getContactName } from '~~/shared/utils/model'
+
+const { contact, guestRowId } = defineProps<{
+  contact: Pick<
+    ContactItemFragment,
+    'accountByAccountId' | 'accountId' | 'firstName' | 'lastName' | 'nickname'
+  >
+  guestRowId: string
+}>()
+const emit = defineEmits<{
+  success: []
+}>()
+
+const contactName = computed(
+  () =>
+    getContactName({ account: contact.accountByAccountId, contact }) ||
+    t('contactNameUnknown'),
+)
+
+const { error, restart, step } = useStepper()
+
+// drawer
+const isOpen = defineModel<boolean>('open')
+const closeDrawer = () => {
+  isOpen.value = false
+}
+const onAnimationEnd = (isOpen: boolean) => {
+  if (isOpen) return
+
+  step.value = 'default'
+}
+
+const deleteGuestByRowIdMutation = useMutation(
+  graphql(`
+    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {
+      deleteGuestByRowId(input: $input) {
+        clientMutationId
+      }
+    }
+  `),
+)
+const isPending = computed(() => deleteGuestByRowIdMutation.fetching.value)
+
+const deleteGuest = async () => {
+  const result = await deleteGuestByRowIdMutation.executeMutation({
+    input: { rowId: guestRowId },
+  })
+
+  if (!getResultData(result)) {
+    error.value = result.error ?? new Error(t('globalErrorNoData'))
+    return
+  }
+
+  closeDrawer()
+  emit('success')
+}
+
+// template
+const { t } = useI18n()
+</script>
+
+<i18n lang="yaml">
+de:
+  contactNameUnknown: einen unbenannten Kontakt
+  error: Fehler
+  guestDelete: Gast löschen
+  guestDeleteQuestion: Möchtest du den Gast {name} wirklich löschen?
+  keepGuest: Nein, behalten
+  restart: Erneut versuchen
+  title: Gast löschen
+en:
+  contactNameUnknown: an unnamed contact
+  error: Error
+  guestDelete: Delete guest
+  guestDeleteQuestion: Do you really want to delete the guest {name}?
+  keepGuest: No, keep them
+  restart: Try again
+  title: Delete guest
+</i18n>

--- a/src/app/components/guest/GuestDeleteDrawer.vue
+++ b/src/app/components/guest/GuestDeleteDrawer.vue
@@ -1,65 +1,16 @@
 <template>
-  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
-    <AppStep v-slot="attributes" :is-active="step === 'default'">
-      <div v-bind="attributes" class="text-center">
-        <TypographySubtitleSmall>
-          {{ t('guestDeleteQuestion', { name: contactName }) }}
-        </TypographySubtitleSmall>
-      </div>
-    </AppStep>
-    <AppStep v-slot="attributes" :is-active="step === 'error'">
-      <div v-bind="attributes">
-        <LayoutPageResult type="error">
-          <template v-if="error" #description>
-            {{ error.message }}
-          </template>
-        </LayoutPageResult>
-      </div>
-    </AppStep>
-    <template #title>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <span v-bind="attributes">
-          {{ t('title') }}
-        </span>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <span v-bind="attributes">
-          {{ t('error') }}
-        </span>
-      </AppStep>
-    </template>
-    <template #footer>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('keepGuest')"
-          variant="secondary"
-          @click="closeDrawer"
-        >
-          {{ t('keepGuest') }}
-        </ButtonColored>
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('guestDelete')"
-          :loading="isPending"
-          variant="primary-critical"
-          @click="deleteGuest"
-        >
-          {{ t('guestDelete') }}
-        </ButtonColored>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('restart')"
-          variant="tertiary"
-          @click="restart"
-        >
-          {{ t('restart') }}
-        </ButtonColored>
-      </AppStep>
-    </template>
-  </AppDrawer>
+  <AppConfirmDeleteDrawer
+    v-model:open="isOpen"
+    :cancel-label="t('keepGuest')"
+    :confirm-label="t('guestDelete')"
+    :error
+    :is-pending="isPending"
+    :title="t('title')"
+    @confirm="onConfirm"
+    @restart="restart"
+  >
+    {{ t('guestDeleteQuestion', { name: contactName }) }}
+  </AppConfirmDeleteDrawer>
 </template>
 
 <script setup lang="ts">
@@ -86,18 +37,7 @@ const contactName = computed(
     t('contactNameUnknown'),
 )
 
-const { error, restart, step } = useStepper()
-
-// drawer
 const isOpen = defineModel<boolean>('open')
-const closeDrawer = () => {
-  isOpen.value = false
-}
-const onAnimationEnd = (isOpen: boolean) => {
-  if (isOpen) return
-
-  step.value = 'default'
-}
 
 const deleteGuestByRowIdMutation = useMutation(
   graphql(`
@@ -108,19 +48,19 @@ const deleteGuestByRowIdMutation = useMutation(
     }
   `),
 )
+const { confirm, error, restart } = useMutationConfirmation()
 const isPending = computed(() => deleteGuestByRowIdMutation.fetching.value)
 
-const deleteGuest = async () => {
-  const result = await deleteGuestByRowIdMutation.executeMutation({
-    input: { rowId: guestRowId },
-  })
+const onConfirm = async () => {
+  const result = await confirm(
+    deleteGuestByRowIdMutation.executeMutation({
+      input: { rowId: guestRowId },
+    }),
+  )
 
-  if (!getResultData(result)) {
-    error.value = result.error ?? new Error(t('globalErrorNoData'))
-    return
-  }
+  if (!result) return
 
-  closeDrawer()
+  isOpen.value = false
   emit('success')
 }
 
@@ -131,18 +71,14 @@ const { t } = useI18n()
 <i18n lang="yaml">
 de:
   contactNameUnknown: einen unbenannten Kontakt
-  error: Fehler
   guestDelete: Gast löschen
   guestDeleteQuestion: Möchtest du den Gast {name} wirklich löschen?
   keepGuest: Nein, behalten
-  restart: Erneut versuchen
   title: Gast löschen
 en:
   contactNameUnknown: an unnamed contact
-  error: Error
   guestDelete: Delete guest
   guestDeleteQuestion: Do you really want to delete the guest {name}?
   keepGuest: No, keep them
-  restart: Try again
   title: Delete guest
 </i18n>

--- a/src/app/components/guest/GuestListItem.vue
+++ b/src/app/components/guest/GuestListItem.vue
@@ -80,7 +80,7 @@
           <AppDropdownItem
             :disabled="pending.deletions.includes(guest.rowId)"
             variant="destructive"
-            @select="delete_(guest.rowId)"
+            @select="onDeleteSelect(guest.rowId)"
           >
             <AppIconTrash />
             <span>
@@ -95,10 +95,17 @@
     </LayoutTd>
   </tr>
   <!-- </Loader> -->
+  <GuestDeleteDrawer
+    v-if="contact"
+    v-model:open="isDeleteDrawerOpen"
+    :contact
+    :guest-row-id="guest.rowId"
+  />
 </template>
 
 <script setup lang="ts">
 import { useMutation } from '@urql/vue'
+import { useMagicKeys } from '@vueuse/core'
 
 import { graphql } from '~~/gql/generated'
 import { getContactItem } from '~~/shared/utils/contact'
@@ -115,8 +122,10 @@ const { event, guest } = defineProps<{
 const { locale, t } = useI18n()
 const localePath = useLocalePath()
 const { copy } = useCopy()
+const { shift } = useMagicKeys()
 
 // data
+const isDeleteDrawerOpen = ref(false)
 const pending = reactive({
   deletions: ref<string[]>([]),
   edits: ref<string[]>([]),
@@ -163,6 +172,14 @@ const delete_ = async (id: string) => {
   pending.deletions.push(id)
   await deleteGuestByRowIdMutation.executeMutation({ input: { rowId: id } })
   pending.deletions.splice(pending.deletions.indexOf(id), 1)
+}
+const onDeleteSelect = (id: string) => {
+  if (shift?.value) {
+    delete_(id)
+    return
+  }
+
+  isDeleteDrawerOpen.value = true
 }
 const send = async (guest: Pick<GuestItemFragment, 'rowId'>) => {
   pending.sends.push(guest.rowId)

--- a/src/app/components/upload/UploadDeleteDrawer.vue
+++ b/src/app/components/upload/UploadDeleteDrawer.vue
@@ -1,65 +1,16 @@
 <template>
-  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
-    <AppStep v-slot="attributes" :is-active="step === 'default'">
-      <div v-bind="attributes" class="text-center">
-        <TypographySubtitleSmall>
-          {{ t('uploadDeleteQuestion') }}
-        </TypographySubtitleSmall>
-      </div>
-    </AppStep>
-    <AppStep v-slot="attributes" :is-active="step === 'error'">
-      <div v-bind="attributes">
-        <LayoutPageResult type="error">
-          <template v-if="error" #description>
-            {{ error.message }}
-          </template>
-        </LayoutPageResult>
-      </div>
-    </AppStep>
-    <template #title>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <span v-bind="attributes">
-          {{ t('title') }}
-        </span>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <span v-bind="attributes">
-          {{ t('error') }}
-        </span>
-      </AppStep>
-    </template>
-    <template #footer>
-      <AppStep v-slot="attributes" :is-active="step === 'default'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('keepUpload')"
-          variant="secondary"
-          @click="closeDrawer"
-        >
-          {{ t('keepUpload') }}
-        </ButtonColored>
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('uploadDelete')"
-          :loading="isPending"
-          variant="primary-critical"
-          @click="deleteUpload"
-        >
-          {{ t('uploadDelete') }}
-        </ButtonColored>
-      </AppStep>
-      <AppStep v-slot="attributes" :is-active="step === 'error'">
-        <ButtonColored
-          v-bind="attributes"
-          :aria-label="t('restart')"
-          variant="tertiary"
-          @click="restart"
-        >
-          {{ t('restart') }}
-        </ButtonColored>
-      </AppStep>
-    </template>
-  </AppDrawer>
+  <AppConfirmDeleteDrawer
+    v-model:open="isOpen"
+    :cancel-label="t('keepUpload')"
+    :confirm-label="t('uploadDelete')"
+    :error
+    :is-pending="isPending"
+    :title="t('title')"
+    @confirm="onConfirm"
+    @restart="restart"
+  >
+    {{ t('uploadDeleteQuestion') }}
+  </AppConfirmDeleteDrawer>
 </template>
 
 <script setup lang="ts">
@@ -74,18 +25,7 @@ const emit = defineEmits<{
   success: []
 }>()
 
-const { error, restart, step } = useStepper()
-
-// drawer
 const isOpen = defineModel<boolean>('open')
-const closeDrawer = () => {
-  isOpen.value = false
-}
-const onAnimationEnd = (isOpen: boolean) => {
-  if (isOpen) return
-
-  step.value = 'default'
-}
 
 const deleteUploadByRowIdMutation = useMutation(
   graphql(`
@@ -96,19 +36,19 @@ const deleteUploadByRowIdMutation = useMutation(
     }
   `),
 )
+const { confirm, error, restart } = useMutationConfirmation()
 const isPending = computed(() => deleteUploadByRowIdMutation.fetching.value)
 
-const deleteUpload = async () => {
-  const result = await deleteUploadByRowIdMutation.executeMutation({
-    input: { rowId: uploadRowId },
-  })
+const onConfirm = async () => {
+  const result = await confirm(
+    deleteUploadByRowIdMutation.executeMutation({
+      input: { rowId: uploadRowId },
+    }),
+  )
 
-  if (!getResultData(result)) {
-    error.value = result.error ?? new Error(t('globalErrorNoData'))
-    return
-  }
+  if (!result) return
 
-  closeDrawer()
+  isOpen.value = false
   emit('success')
 }
 
@@ -118,16 +58,12 @@ const { t } = useI18n()
 
 <i18n lang="yaml">
 de:
-  error: Fehler
   keepUpload: Nein, behalten
-  restart: Erneut versuchen
   title: Bild löschen
   uploadDelete: Bild löschen
   uploadDeleteQuestion: Möchtest du dieses Bild wirklich löschen?
 en:
-  error: Error
   keepUpload: No, keep it
-  restart: Try again
   title: Delete image
   uploadDelete: Delete image
   uploadDeleteQuestion: Do you really want to delete this image?

--- a/src/app/components/upload/UploadDeleteDrawer.vue
+++ b/src/app/components/upload/UploadDeleteDrawer.vue
@@ -1,0 +1,134 @@
+<template>
+  <AppDrawer v-model:open="isOpen" @animation-end="onAnimationEnd">
+    <AppStep v-slot="attributes" :is-active="step === 'default'">
+      <div v-bind="attributes" class="text-center">
+        <TypographySubtitleSmall>
+          {{ t('uploadDeleteQuestion') }}
+        </TypographySubtitleSmall>
+      </div>
+    </AppStep>
+    <AppStep v-slot="attributes" :is-active="step === 'error'">
+      <div v-bind="attributes">
+        <LayoutPageResult type="error">
+          <template v-if="error" #description>
+            {{ error.message }}
+          </template>
+        </LayoutPageResult>
+      </div>
+    </AppStep>
+    <template #title>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <span v-bind="attributes">
+          {{ t('title') }}
+        </span>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <span v-bind="attributes">
+          {{ t('error') }}
+        </span>
+      </AppStep>
+    </template>
+    <template #footer>
+      <AppStep v-slot="attributes" :is-active="step === 'default'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('keepUpload')"
+          variant="secondary"
+          @click="closeDrawer"
+        >
+          {{ t('keepUpload') }}
+        </ButtonColored>
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('uploadDelete')"
+          :loading="isPending"
+          variant="primary-critical"
+          @click="deleteUpload"
+        >
+          {{ t('uploadDelete') }}
+        </ButtonColored>
+      </AppStep>
+      <AppStep v-slot="attributes" :is-active="step === 'error'">
+        <ButtonColored
+          v-bind="attributes"
+          :aria-label="t('restart')"
+          variant="tertiary"
+          @click="restart"
+        >
+          {{ t('restart') }}
+        </ButtonColored>
+      </AppStep>
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { useMutation } from '@urql/vue'
+
+import { graphql } from '~~/gql/generated'
+
+const { uploadRowId } = defineProps<{
+  uploadRowId: string
+}>()
+const emit = defineEmits<{
+  success: []
+}>()
+
+const { error, restart, step } = useStepper()
+
+// drawer
+const isOpen = defineModel<boolean>('open')
+const closeDrawer = () => {
+  isOpen.value = false
+}
+const onAnimationEnd = (isOpen: boolean) => {
+  if (isOpen) return
+
+  step.value = 'default'
+}
+
+const deleteUploadByRowIdMutation = useMutation(
+  graphql(`
+    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {
+      deleteUploadByRowId(input: $input) {
+        clientMutationId
+      }
+    }
+  `),
+)
+const isPending = computed(() => deleteUploadByRowIdMutation.fetching.value)
+
+const deleteUpload = async () => {
+  const result = await deleteUploadByRowIdMutation.executeMutation({
+    input: { rowId: uploadRowId },
+  })
+
+  if (!getResultData(result)) {
+    error.value = result.error ?? new Error(t('globalErrorNoData'))
+    return
+  }
+
+  closeDrawer()
+  emit('success')
+}
+
+// template
+const { t } = useI18n()
+</script>
+
+<i18n lang="yaml">
+de:
+  error: Fehler
+  keepUpload: Nein, behalten
+  restart: Erneut versuchen
+  title: Bild löschen
+  uploadDelete: Bild löschen
+  uploadDeleteQuestion: Möchtest du dieses Bild wirklich löschen?
+en:
+  error: Error
+  keepUpload: No, keep it
+  restart: Try again
+  title: Delete image
+  uploadDelete: Delete image
+  uploadDeleteQuestion: Do you really want to delete this image?
+</i18n>

--- a/src/app/components/upload/UploadGallery.vue
+++ b/src/app/components/upload/UploadGallery.vue
@@ -14,14 +14,16 @@
             :key="upload.rowId"
             class="relative box-border border-4"
             :class="[
-              ...(pending.deletions.includes(upload.rowId)
+              ...(isDeleteDrawerOpen && uploadToDelete?.rowId === upload.rowId
                 ? ['animate-pulse']
                 : []),
               ...(isSelectable && upload === selectedItem
                 ? ['border-red-600']
                 : ['border-transparent']),
             ]"
-            :disabled="pending.deletions.includes(upload.rowId)"
+            :disabled="
+              isDeleteDrawerOpen && uploadToDelete?.rowId === upload.rowId
+            "
             @click="toggleSelect(upload)"
           >
             <LoaderImage
@@ -40,7 +42,7 @@
               <AppButton
                 :aria-label="t('iconTrashLabel')"
                 class="flex h-full justify-center"
-                @click="deleteUpload(upload)"
+                @click="onDeleteSelect(upload)"
               >
                 <AppIconTrash
                   class="text-text-bright m-1"
@@ -111,6 +113,12 @@
       <template #header>{{ t('uploadNew') }}</template>
       <template #submit-icon><AppIconArrowUpTray /></template>
     </Modal>
+    <UploadDeleteDrawer
+      v-if="uploadToDelete"
+      v-model:open="isDeleteDrawerOpen"
+      :upload-row-id="uploadToDelete.rowId"
+      @success="onDeleteSuccess"
+    />
   </Loader>
 </template>
 
@@ -148,12 +156,13 @@ const templateInputProfilePicture = useTemplateRef('inputProfilePicture')
 const after = ref<string | null>()
 const fileSelectedUrl = ref<string>()
 const fileSelectedMimeType = ref<string>()
+const isDeleteDrawerOpen = ref(false)
 const isModalUploadGalleryOpen = ref<boolean>()
 const isUploadSubmitting = ref(false)
 const uploadSubmitErrors = ref()
-const pending = reactive({
-  deletions: ref<string[]>([]),
-})
+const uploadToDelete = ref<{
+  rowId: string
+}>()
 const selectedItem = ref<{
   rowId?: string | null
 }>()
@@ -194,15 +203,6 @@ const allUploadsQuery = useQuery({
     createdBy: store.signedInAccountId,
   })),
 })
-const deleteUploadByRowIdMutation = useMutation(
-  graphql(`
-    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {
-      deleteUploadByRowId(input: $input) {
-        clientMutationId
-      }
-    }
-  `),
-)
 const uploadCreateMutation = useMutation(
   graphql(`
     mutation CreateUpload($input: CreateUploadInput!) {
@@ -219,7 +219,6 @@ const uploadCreateMutation = useMutation(
 const api = await useApiData([
   accountUploadQuotaBytesQuery,
   allUploadsQuery,
-  deleteUploadByRowIdMutation,
   uploadCreateMutation,
 ])
 const uploads = computed(
@@ -262,25 +261,13 @@ const selectProfilePicture = async () => {
     await navigateTo(pathUpload)
   }
 }
-const executeUrqlRequest = useExecuteUrqlRequest()
-const deleteUpload = async (
+const onDeleteSelect = (
   upload: Pick<(typeof uploads.value)[number], 'rowId'>,
 ) => {
-  // pending.deletions.push(upload.rowId)
-  const result = await executeUrqlRequest({
-    errorMessageI18n: t('uploadDeleteFailed'),
-    progress: {
-      id: upload.rowId,
-      idArray: pending.deletions,
-    },
-    request: deleteUploadByRowIdMutation.executeMutation({
-      input: { rowId: upload.rowId },
-    }),
-  })
-  // pending.deletions.splice(pending.deletions.indexOf(upload.rowId), 1)
-
-  if (!result) return
-
+  uploadToDelete.value = upload
+  isDeleteDrawerOpen.value = true
+}
+const onDeleteSuccess = () => {
   allUploadsQuery.executeQuery()
 }
 const getMimeType = (file: ArrayBuffer, fallback?: string) => {
@@ -452,7 +439,6 @@ de:
   upload: Hochladen
   uploadAlt: Ein hochgeladenes Bild.
   uploadAltFailed: Ein Bild, das nicht vollständig hochgeladen wurde.
-  uploadDeleteFailed: Das Löschen des Elements ist fehlgeschlagen!
   uploadError: 'Fehler: Dateien wurden nicht erfolgreich hochgeladen!'
   uploadNew: Lade ein neues Bild hoch
   uploadSize: 'Größe: {size}'
@@ -464,7 +450,6 @@ en:
   upload: Upload
   uploadAlt: An uploaded image.
   uploadAltFailed: "An image which hasn't been fully uploaded."
-  uploadDeleteFailed: Deleting upload failed!
   uploadError: 'Error: Upload failed!'
   uploadNew: Upload a new image
   uploadSize: 'Size: {size}'

--- a/src/app/composables/mutationConfirmation.ts
+++ b/src/app/composables/mutationConfirmation.ts
@@ -1,0 +1,25 @@
+import type { OperationResult } from '@urql/core'
+import type { AnyVariables } from '@urql/vue'
+
+export const useMutationConfirmation = () => {
+  const { t } = useI18n({ useScope: 'global' })
+  const error = ref<Error>()
+
+  const confirm = async <S, V extends AnyVariables = AnyVariables>(
+    mutation: Promise<OperationResult<S, V>>,
+  ) => {
+    const result = await mutation
+
+    if (!getResultData(result)) {
+      error.value = result.error ?? new Error(t('globalErrorNoData'))
+      return
+    }
+
+    return result
+  }
+  const restart = () => {
+    error.value = undefined
+  }
+
+  return { confirm, error, restart }
+}

--- a/src/app/pages/account/edit/[username].vue
+++ b/src/app/pages/account/edit/[username].vue
@@ -45,9 +45,8 @@
           </ButtonColored>
           <ButtonColored
             :aria-label="t('remove')"
-            :loading="deleteProfilePictureByRowIdMutation.fetching.value"
             variant="secondary"
-            @click="removeProfilePicture"
+            @click="openProfilePictureRemoveDrawer"
           >
             <TypographyLabel v-slot="attributes">
               <div v-bind="attributes">
@@ -59,6 +58,11 @@
         <ModalUploadSelection
           v-model="isModalUploadSelectionOpen"
           @select="onUploadSelect"
+        />
+        <AccountProfilePictureRemoveDrawer
+          v-if="account?.profilePictureByAccountId?.rowId"
+          v-model:open="isProfilePictureRemoveDrawerOpen"
+          :profile-picture-row-id="account.profilePictureByAccountId.rowId"
         />
       </div>
       <AppInputTextarea
@@ -158,8 +162,12 @@ const account = computed(() => api.value.data.accountByUsername)
 
 // profile picture
 const isModalUploadSelectionOpen = ref<boolean>()
+const isProfilePictureRemoveDrawerOpen = ref(false)
 const showModalUploadSelection = () => {
   isModalUploadSelectionOpen.value = true
+}
+const openProfilePictureRemoveDrawer = () => {
+  isProfilePictureRemoveDrawerOpen.value = true
 }
 
 const createProfilePictureMutation = useMutation(


### PR DESCRIPTION
Adds a confirmation drawer before deleting a guest invitation, a contact, an uploaded image, or an account's profile picture, so these previously one-click, unconfirmed deletions require an explicit confirm step first. The guest drawer also stays skippable by holding Shift, as requested in the issue.

Closes #348.