### PR TITLE
fix(event): remove unused location field from ical payload validation

### DIFF
--- a/src/app/pages/guest/view/[id]/index.vue
+++ b/src/app/pages/guest/view/[id]/index.vue
@@ -449,9 +449,9 @@ const downloadIcal = async () => {
 
   const response = await $csrfFetch('/api/model/event/ical', {
     body: {
-      contact,
-      event,
-      guest,
+      contact: contact.value,
+      event: event.value,
+      guest: guest.value,
     },
     method: 'POST',
   })

--- a/src/server/api/model/event/ical.post.ts
+++ b/src/server/api/model/event/ical.post.ts
@@ -16,7 +16,6 @@ const icalPostBodySchema = z.object({
     }),
     description: z.string().nullable(),
     end: z.string().nullable(),
-    location: z.string().nullable(),
     name: z.string(),
     rowId: z.string(),
     start: z.string(),

--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -35,7 +35,6 @@ type Event = {
   isArchived: boolean
   isInPerson: boolean
   isRemote: boolean
-  location: string | null
   name: string
   slug: string
   start: string // Date

--- a/tests/e2e/specs/server/ical.spec.ts
+++ b/tests/e2e/specs/server/ical.spec.ts
@@ -31,4 +31,65 @@ test.describe('api load', () => {
       expect(resp.statusText()).toEqual(inputDataElement.message)
     }
   })
+
+  // regression test: both real callers of this endpoint (the event invitation
+  // email in `src/server/utils/notification.ts` and the manual download button
+  // on `src/app/pages/guest/view/[id]/index.vue`) have repeatedly drifted out
+  // of sync with `icalPostBodySchema`, only surfacing as a runtime 400 once
+  // deployed. This asserts both shapes keep validating and producing a usable
+  // `.ics` response.
+  test('accepts a payload shaped like the event invitation email', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/model/event/ical', {
+      data: {
+        event: {
+          accountByCreatedBy: { username: 'eventAuthor' },
+          description: 'description',
+          end: '2024-10-15T16:00:00Z',
+          name: 'name',
+          rowId: '00000000-0000-0000-0000-000000000000',
+          slug: 'slug',
+          start: '2024-10-15T14:00:00Z',
+          visibility: 'public',
+        },
+        guest: { rowId: '00000000-0000-0000-0000-000000000001' },
+      },
+    })
+
+    expect(resp.status()).toEqual(200)
+    expect(resp.headers()['content-type']).toEqual('text/calendar')
+
+    const body = await resp.text()
+    expect(body).toContain('SUMMARY:name')
+    expect(body).toContain('UID:00000000-0000-0000-0000-000000000000')
+  })
+
+  test('accepts a payload shaped like the guest view manual download', async ({
+    request,
+  }) => {
+    const resp = await request.post('/api/model/event/ical', {
+      data: {
+        contact: { firstName: 'firstName', lastName: 'lastName' },
+        event: {
+          accountByCreatedBy: { username: 'eventAuthor' },
+          description: null,
+          end: null,
+          name: 'name',
+          rowId: '00000000-0000-0000-0000-000000000000',
+          slug: 'slug',
+          start: '2024-10-15T14:00:00Z',
+          visibility: 'public',
+        },
+        guest: { rowId: '00000000-0000-0000-0000-000000000001' },
+      },
+    })
+
+    expect(resp.status()).toEqual(200)
+    expect(resp.headers()['content-type']).toEqual('text/calendar')
+
+    const body = await resp.text()
+    expect(body).toContain('SUMMARY:name')
+    expect(body).toContain('UID:00000000-0000-0000-0000-000000000000')
+  })
 })


### PR DESCRIPTION
Removes the `location` field from the ical payload's event schema and the invitation notification's `Event` type. The field was never populated (the Postgres `invite()` function doesn't select it, and `getIcalString` doesn't use it), so it was always `undefined` in the request body, causing zod to reject event invitation emails with "Invalid input: expected string, received undefined" and drop the `.ics` attachment.

While auditing the endpoint, also fixes the guest-view page's manual `.ics` download, which passed unwrapped Vue `computed()` refs into the request body instead of their `.value`, throwing a circular-structure error on every click.

Adds regression coverage exercising both real callers' payload shapes against `/api/model/event/ical`, since the schema had drifted out of sync with its callers multiple times without any test catching it.