### PR TITLE
fix(event): match invitation email ical method to mime type

### DIFF
--- a/src/server/utils/notification.ts
+++ b/src/server/utils/notification.ts
@@ -467,7 +467,7 @@ export const sendEventInvitationMail = async ({
             icalEvent: {
               content: icalText,
               filename: eventCreatorUsername + '_' + event.slug + '.ics',
-              method: 'request',
+              method: 'publish',
             },
           }
         : {}),


### PR DESCRIPTION
The event invitation email's `.ics` attachment set the MIME header to `method=REQUEST` while the calendar body itself declared `METHOD:PUBLISH`, which Outlook rejects with "Inbound Mime method and ICAL method mismatch" / "Invalid ICAL element: VCALENDAR". Aligning nodemailer's `icalEvent.method` to `publish` matches the actual calendar content, which has no attendee/RSVP handling implemented.