### PR TITLE
feat(components): confirm external link navigation

### DIFF
--- a/src/app/components/app/AppLink.vue
+++ b/src/app/components/app/AppLink.vue
@@ -6,9 +6,14 @@
     :external="isExternal"
     :target="targetComputed"
     :to
-    @click="emit('click', $event)"
+    @click="onClick"
   >
     <slot />
+    <ModalExternalLink
+      v-if="isLeavingSite"
+      v-model="isModalExternalLinkOpen"
+      :url="to.toString()"
+    />
   </NuxtLink>
 </template>
 
@@ -44,6 +49,9 @@ const emit = defineEmits<{
   click: [event: MouseEvent]
 }>()
 
+// data
+const isModalExternalLinkOpen = ref(false)
+
 // computations
 const classComputed = computed(() =>
   [
@@ -53,11 +61,20 @@ const classComputed = computed(() =>
     ...(isUnderlined ? ['underline'] : []),
   ].join(' '),
 )
+const isLeavingSite = computed(() => /^(ftp|http(s)?):\/\//.test(to.toString()))
+const isMailto = computed(() => /^mailto:/.test(to.toString()))
 const targetComputed = computed(
   () =>
-    target ||
-    (to.toString().match(/^((ftp|http(s)?):\/\/|(mailto):)/)
-      ? '_blank'
-      : undefined),
+    target || (isLeavingSite.value || isMailto.value ? '_blank' : undefined),
 )
+
+// methods
+const onClick = (event: MouseEvent) => {
+  if (isLeavingSite.value) {
+    event.preventDefault()
+    isModalExternalLinkOpen.value = true
+  }
+
+  emit('click', event)
+}
 </script>

--- a/src/app/components/modal/ModalExternalLink.vue
+++ b/src/app/components/modal/ModalExternalLink.vue
@@ -1,0 +1,56 @@
+<template>
+  <Modal v-model="open">
+    <template #header>{{ t('header') }}</template>
+    <p class="break-all">{{ t('description') }}</p>
+    <p class="mt-2 break-all opacity-60">{{ url }}</p>
+    <template #footer>
+      <ButtonColored
+        :aria-label="t('cancel')"
+        variant="secondary"
+        @click="onCancel"
+      >
+        {{ t('cancel') }}
+        <template #prefix>
+          <AppIconXMark />
+        </template>
+      </ButtonColored>
+      <ButtonColored :aria-label="t('continue')" @click="onSubmit">
+        {{ t('continue') }}
+        <template #prefix>
+          <AppIconCheckCircleSolid />
+        </template>
+      </ButtonColored>
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+const { url } = defineProps<{
+  url: string
+}>()
+
+const open = defineModel<boolean>()
+const { t } = useI18n()
+
+// methods
+const onCancel = () => {
+  open.value = false
+}
+const onSubmit = () => {
+  open.value = false
+  navigateTo(url, { external: true, open: { target: '_blank' } })
+}
+</script>
+
+<i18n lang="yaml">
+de:
+  cancel: Abbrechen
+  continue: Fortfahren
+  description: Du verlässt vibetype und wirst zu folgender Adresse weitergeleitet.
+  header: Du verlässt vibetype
+en:
+  cancel: Cancel
+  continue: Continue
+  description: You are leaving vibetype and will be redirected to the following address.
+  header: You are leaving vibetype
+</i18n>


### PR DESCRIPTION
Adds a confirmation modal that warns users before navigating to an external link, wired centrally into `AppLink` so it applies everywhere links are rendered (buttons, cards, menu items, etc.).