### PR TITLE
fix(account): terms checkbox label and username input focus

### DIFF
--- a/src/app/components/form/FormCheckbox.vue
+++ b/src/app/components/form/FormCheckbox.vue
@@ -1,14 +1,14 @@
 <template>
-  <div>
+  <div class="flex items-start gap-4">
     <input
       :id="`input-${formKey}`"
       :checked="value"
-      class="rounded-sm"
+      class="mt-1.5 rounded-sm"
       :disabled="isDisabled"
       type="checkbox"
       @change="emit('change', ($event.target as HTMLInputElement).checked)"
     />
-    <label class="pl-2" :for="`input-${formKey}`"><slot /></label>
+    <label :for="`input-${formKey}`"><slot /></label>
   </div>
 </template>
 

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -106,7 +106,6 @@
           <div class="relative">
             <FormAuthInput
               :aria-label="t('usernamePlaceholder')"
-              :disabled="usernameField.isLoading.value"
               :model-value="usernameField.value.value"
               :placeholder="t('usernamePlaceholder')"
               type="text"

--- a/src/app/pages/account/create/index.vue
+++ b/src/app/pages/account/create/index.vue
@@ -37,28 +37,30 @@
           <div class="flex items-start gap-3">
             <FormCheckbox
               :aria-label="t('agreeCheckboxLabel')"
+              form-key="agree-to-terms"
               :value="agreedToTerms"
               @change="agreedToTerms = $event"
-            />
-            <span class="text-sm text-gray-500 dark:text-gray-400">
-              {{ t('agreePrefix') }}
-              <NuxtLinkLocale
-                class="font-semibold text-green-600"
-                to="docs-legal-terms"
-                >{{ t('termsOfService') }}</NuxtLinkLocale
-              >{{ t('legalComma') }}
-              <NuxtLinkLocale
-                class="font-semibold text-green-600"
-                to="docs-legal-imprint"
-                >{{ t('imprint') }}</NuxtLinkLocale
-              >
-              {{ t('and') }}
-              <NuxtLinkLocale
-                class="font-semibold text-green-600"
-                to="docs-legal-privacy"
-                >{{ t('privacyPolicy') }}</NuxtLinkLocale
-              >
-            </span>
+            >
+              <span class="text-sm text-gray-500 dark:text-gray-400">
+                {{ t('agreePrefix') }}
+                <NuxtLinkLocale
+                  class="font-semibold text-green-600"
+                  to="docs-legal-terms"
+                  >{{ t('termsOfService') }}</NuxtLinkLocale
+                >{{ t('legalComma') }}
+                <NuxtLinkLocale
+                  class="font-semibold text-green-600"
+                  to="docs-legal-imprint"
+                  >{{ t('imprint') }}</NuxtLinkLocale
+                >
+                {{ t('and') }}
+                <NuxtLinkLocale
+                  class="font-semibold text-green-600"
+                  to="docs-legal-privacy"
+                  >{{ t('privacyPolicy') }}</NuxtLinkLocale
+                >
+              </span>
+            </FormCheckbox>
           </div>
           <p v-if="termsError" class="text-sm text-red-600">
             {{ termsError }}

--- a/tests/e2e/specs/pages/account/create/index.spec.ts-snapshots/visual-regression-looks-as-before-1-Mobile-Chrome-linux.png
+++ b/tests/e2e/specs/pages/account/create/index.spec.ts-snapshots/visual-regression-looks-as-before-1-Mobile-Chrome-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:94572da4f36f93486897a0f44eea0a23f41eedb9850bd630f100e7c8dda23397
-size 25772
+oid sha256:8f0f471af9a12816eb7f389b173cdf293f80567aa25ebe4c760fe799b8c026f1
+size 25795

--- a/tests/e2e/specs/pages/account/create/index.spec.ts-snapshots/visual-regression-looks-as-before-1-chromium-linux.png
+++ b/tests/e2e/specs/pages/account/create/index.spec.ts-snapshots/visual-regression-looks-as-before-1-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c0c8cf1faa1686fe7824149f800cf08f9c1e1f0b65054fde7c291a6768b5175f
-size 29591
+oid sha256:0928a49e3c174f188a663afe3ab90b5c966e5ee87672eeedfda512a212eb642a
+size 29618


### PR DESCRIPTION
Fixes two bugs in the account creation flow:
- The "I agree to Vibetype's Terms of Service" text was rendered outside the checkbox's `<label>`, so clicking it did nothing; the text now lives in `FormCheckbox`'s slot so it's properly associated.
- The username field lost focus after every keystroke once touched, because `disabled` was bound to the async validation's loading state, and disabling a focused input forces a browser blur. The `disabled` binding is removed; the existing spinner already shows the loading state.