### PR TITLE
fix(tiptap): sync external value updates and empty-content emission

### DIFF
--- a/src/app/components/app/AppTipTap.vue
+++ b/src/app/components/app/AppTipTap.vue
@@ -313,6 +313,16 @@ const editor = useEditor({
   },
 })
 
+watch(
+  () => value,
+  (newValue) => {
+    if (!editor.value) return
+    if ((newValue ?? '') === editor.value.getHTML()) return
+
+    editor.value.commands.setContent(newValue ?? '', { emitUpdate: false })
+  },
+)
+
 // data
 const isActive = reactive({
   heading1: false,
@@ -387,7 +397,9 @@ const setLink = () => {
   }
 
   const location = getLocation(url)
-  const urlHost = `${location.hostname}:${location.port}`
+  const urlHost = location.port
+    ? `${location.hostname}:${location.port}`
+    : location.hostname
 
   // update link
   editor.value
@@ -400,11 +412,16 @@ const setLink = () => {
 const updateDebounced = debounce(
   () => {
     if (!editor.value) return
-    emit('input', editor.value?.getHTML())
+    emit('input', editor.value.isEmpty ? '' : editor.value.getHTML())
   },
   1000,
   { leading: true },
 )
+
+onBeforeUnmount(() => {
+  updateIsActive.cancel()
+  updateDebounced.cancel()
+})
 </script>
 
 <i18n lang="yaml">


### PR DESCRIPTION
Watches the `value` prop so external changes update the editor content, emits an empty string instead of tiptap's empty-paragraph markup when the editor has no content, fixes the link host formatting to omit the colon when there is no port, and cancels the debounced update and active-state handlers on unmount.