### PR TITLE
feat(invitation): move organizer feedback override to guest list

### DIFF
--- a/src/app/components/guest/GuestListItem.vue
+++ b/src/app/components/guest/GuestListItem.vue
@@ -78,6 +78,32 @@
             </span>
           </AppDropdownItem>
           <AppDropdownItem
+            v-if="
+              guest.feedback === null ||
+              guest.feedback === InvitationFeedback.Canceled
+            "
+            :disabled="pending.feedbacks.includes(guest.rowId)"
+            @select="setFeedback(guest.rowId, InvitationFeedback.Accepted)"
+          >
+            <AppIconCheckCircleSolid />
+            <span>
+              {{ t('guestFeedbackAccept') }}
+            </span>
+          </AppDropdownItem>
+          <AppDropdownItem
+            v-if="
+              guest.feedback === null ||
+              guest.feedback === InvitationFeedback.Accepted
+            "
+            :disabled="pending.feedbacks.includes(guest.rowId)"
+            @select="setFeedback(guest.rowId, InvitationFeedback.Canceled)"
+          >
+            <AppIconXCircleSolid />
+            <span>
+              {{ t('guestFeedbackCancel') }}
+            </span>
+          </AppDropdownItem>
+          <AppDropdownItem
             :disabled="pending.deletions.includes(guest.rowId)"
             variant="destructive"
             @select="onDeleteSelect(guest.rowId)"
@@ -107,6 +133,7 @@
 import { useMutation } from '@urql/vue'
 import { useMagicKeys } from '@vueuse/core'
 
+import { InvitationFeedback } from '~~/gql/generated/graphcache'
 import { graphql } from '~~/gql/generated'
 import { getContactItem } from '~~/shared/utils/contact'
 import type {
@@ -129,6 +156,7 @@ const isDeleteDrawerOpen = ref(false)
 const pending = reactive({
   deletions: ref<string[]>([]),
   edits: ref<string[]>([]),
+  feedbacks: ref<string[]>([]),
   sends: ref<string[]>([]),
 })
 
@@ -147,6 +175,18 @@ const inviteMutation = useMutation(
     mutation Invite($input: InviteInput!) {
       invite(input: $input) {
         clientMutationId
+      }
+    }
+  `),
+)
+const updateGuestByRowIdMutation = useMutation(
+  graphql(`
+    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {
+      updateGuestByRowId(input: $input) {
+        guest {
+          feedback
+          id
+        }
       }
     }
   `),
@@ -181,6 +221,19 @@ const onDeleteSelect = (id: string) => {
 
   isDeleteDrawerOpen.value = true
 }
+const setFeedback = async (id: string, feedback: InvitationFeedback) => {
+  pending.feedbacks.push(id)
+
+  const result = await updateGuestByRowIdMutation.executeMutation({
+    input: { guestPatch: { feedback }, rowId: id },
+  })
+
+  pending.feedbacks.splice(pending.feedbacks.indexOf(id), 1)
+
+  if (!getResultData(result)) return
+
+  toast.success(t('guestFeedbackSuccess'))
+}
 const send = async (guest: Pick<GuestItemFragment, 'rowId'>) => {
   pending.sends.push(guest.rowId)
 
@@ -207,6 +260,9 @@ de:
   copySuccess: Der Einladungslink wurde in die Zwischenablage kopiert.
   disabledReasonEmailAddressNone: Diesem Kontakt fehlt eine E-Mail-Adresse.
   guestDelete: Gast löschen
+  guestFeedbackAccept: Als zugesagt markieren
+  guestFeedbackCancel: Als abgesagt markieren
+  guestFeedbackSuccess: Der Rückmeldestatus wurde aktualisiert.
   guestLink: Einladungslink kopieren
   guestSend: Einladung versenden
   guestView: Einladung anzeigen
@@ -216,6 +272,9 @@ en:
   copySuccess: The guest link has been copied to the clipboard.
   disabledReasonEmailAddressNone: This contact does not have an associated email address.
   guestDelete: Delete guest
+  guestFeedbackAccept: Mark as accepted
+  guestFeedbackCancel: Mark as declined
+  guestFeedbackSuccess: The feedback status was updated.
   guestLink: Copy invitation link
   guestSend: Send invitation
   guestView: View invitation

--- a/src/app/pages/guest/view/[id]/index.vue
+++ b/src/app/pages/guest/view/[id]/index.vue
@@ -13,14 +13,7 @@
     :error="{ message: t('errorAccountMissing'), status: 404 }"
   />
   <div v-else class="flex flex-col gap-4">
-    <CardStateInfo
-      v-if="
-        account.rowId === store.signedInAccountId &&
-        guest.contactByContactId?.accountByAccountId?.rowId !==
-          store.signedInAccountId
-      "
-      class="flex flex-col gap-2"
-    >
+    <CardStateInfo v-if="isOrganizerPreview" class="flex flex-col gap-2">
       {{ t('invitationViewFor', { name: contactName }) }}
       <ButtonColored
         :aria-label="t('invitationSelectionClear')"
@@ -144,31 +137,45 @@
             : 'col-span-6'
         "
       >
-        <div class="flex items-center justify-center gap-4">
+        <div
+          v-if="isOrganizerPreview"
+          class="flex items-center justify-center gap-4"
+        >
+          <div
+            v-if="guest.feedback === InvitationFeedback.Accepted"
+            class="flex items-center font-semibold text-green-600 dark:text-green-500"
+          >
+            <AppIconCheckCircleSolid class="mr-2 shrink-0" />
+            <span>
+              {{ t('invitationAcceptedAdmin', { name: contactName }) }}
+            </span>
+          </div>
+          <div
+            v-else-if="guest.feedback === InvitationFeedback.Canceled"
+            class="flex items-center font-semibold text-(--semantic-critic-text)"
+          >
+            <AppIconXCircleSolid class="mr-2 shrink-0" />
+            <span>
+              {{ t('invitationCanceledAdmin', { name: contactName }) }}
+            </span>
+          </div>
+          <div v-else class="flex items-center font-semibold">
+            <span>{{
+              t('invitationPendingAdmin', { name: contactName })
+            }}</span>
+          </div>
+        </div>
+        <div v-else class="flex items-center justify-center gap-4">
           <ButtonColored
             v-if="
               guest.feedback === null ||
               guest.feedback === InvitationFeedback.Canceled
             "
-            :aria-label="
-              event.accountByCreatedBy.username !== store.signedInUsername
-                ? t('invitationAccept')
-                : t('invitationAcceptAdmin', {
-                    name: contactName,
-                  })
-            "
+            :aria-label="t('invitationAccept')"
             :loading="isUpdatingAccept"
             @click="accept"
           >
-            <span>
-              {{
-                event.accountByCreatedBy.username !== store.signedInUsername
-                  ? t('invitationAccept')
-                  : t('invitationAcceptAdmin', {
-                      name: contactName,
-                    })
-              }}
-            </span>
+            <span>{{ t('invitationAccept') }}</span>
             <template #prefix>
               <AppIconCheckCircleSolid class="shrink-0" />
             </template>
@@ -181,40 +188,18 @@
               class="mr-2 shrink-0"
               :title="t('invitationAccepted')"
             />
-            <span>
-              {{
-                event.accountByCreatedBy.username !== store.signedInUsername
-                  ? t('invitationAccepted')
-                  : t('invitationAcceptedAdmin', {
-                      name: contactName,
-                    })
-              }}
-            </span>
+            <span>{{ t('invitationAccepted') }}</span>
           </div>
           <ButtonColored
             v-if="
               guest.feedback === null ||
               guest.feedback === InvitationFeedback.Accepted
             "
-            :aria-label="
-              event.accountByCreatedBy.username !== store.signedInUsername
-                ? t('invitationCancel')
-                : t('invitationCancelAdmin', {
-                    name: contactName,
-                  })
-            "
+            :aria-label="t('invitationCancel')"
             :loading="isUpdatingCancel"
             @click="cancel"
           >
-            <span>
-              {{
-                event.accountByCreatedBy.username !== store.signedInUsername
-                  ? t('invitationCancel')
-                  : t('invitationCancelAdmin', {
-                      name: contactName,
-                    })
-              }}
-            </span>
+            <span>{{ t('invitationCancel') }}</span>
             <template #prefix>
               <AppIconXCircleSolid class="shrink-0" />
             </template>
@@ -227,15 +212,7 @@
               class="mr-2 shrink-0"
               :title="t('invitationCanceled')"
             />
-            <span>
-              {{
-                event.accountByCreatedBy.username !== store.signedInUsername
-                  ? t('invitationCanceled')
-                  : t('invitationCanceledAdmin', {
-                      name: contactName,
-                    })
-              }}
-            </span>
+            <span>{{ t('invitationCanceled') }}</span>
           </div>
         </div>
       </div>
@@ -498,6 +475,12 @@ const contactName = computed(() =>
     ? getContactName({ account: contactAccount.value, contact: contact.value })
     : undefined,
 )
+const isOrganizerPreview = computed(
+  () =>
+    account.value?.rowId === store.signedInAccountId &&
+    guest.value?.contactByContactId?.accountByAccountId?.rowId !==
+      store.signedInAccountId,
+)
 
 // map
 const positionInitial = computed(() =>
@@ -558,13 +541,12 @@ de:
   # iCalHint: Die heruntergeladene Datei kann dann mit deiner Kalender-Anwendung geöffnet werden.
   iCalFetchError: iCal-Daten konnten nicht geladen werden!
   invitationAccept: Einladung annehmen
-  invitationAcceptAdmin: Einladung im Namen von {name} annehmen
   invitationAccepted: Einladung angenommen
   invitationAcceptedAdmin: Einladung im Namen von {name} angenommen
   invitationCancel: Einladung ablehnen
-  invitationCancelAdmin: Einladung im Namen von {name} ablehnen
   invitationCanceled: Einladung abgelehnt
   invitationCanceledAdmin: Einladung im Namen von {name} abgelehnt
+  invitationPendingAdmin: '{name} hat noch nicht geantwortet.'
   invitationSelectionClear: Zurück zur Einladungsübersicht
   invitationViewFor: Du schaust dir die Einladung für {name} an. Alle Personen, die den Link zu dieser Seite bzw. die ID dieser Einladung kennen, können auf diese Einladung zugreifen und mit ihr interagieren.
   ogImageAlt: Das Vorschaubild für die Veranstaltung.
@@ -584,13 +566,12 @@ en:
   # iCalHint: You can open the downloaded file in your calendar app.
   iCalFetchError: Could not get iCal data!
   invitationAccept: Accept invitation
-  invitationAcceptAdmin: Accept invitation on behalf of {name}
   invitationAccepted: Invitation accepted
   invitationAcceptedAdmin: Invitation accepted on behalf of {name}
   invitationCancel: Decline invitation
-  invitationCancelAdmin: Decline invitation on behalf of {name}
   invitationCanceled: Invitation declined
   invitationCanceledAdmin: Invitation declined on behalf of {name}
+  invitationPendingAdmin: '{name} has not responded yet.'
   invitationSelectionClear: Back to the invitation overview
   invitationViewFor: You're viewing the invitation for {name}. Anyone knowing the link to this page or this invitation's id can access this invitation and interact with it.
   ogImageAlt: The event's preview image.

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -16,12 +16,13 @@ import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-
 type Documents = {
   '\n    mutation AccountDelete($input: AccountDeleteInput!) {\n      accountDelete(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountDeleteDocument
   '\n    query AccountByRowId($id: UUID!) {\n      accountByRowId(rowId: $id) {\n        id\n        profilePictureByAccountId {\n          id\n          rowId\n          uploadByUploadId {\n            id\n            rowId\n            storageKey\n          }\n        }\n        rowId\n        username\n      }\n    }\n  ': typeof types.AccountByRowIdDocument
+  '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteProfilePictureByRowIdMutationDocument
   '\n  query AccountSearch($after: Cursor, $first: Int, $username: String) {\n    allAccounts(\n      after: $after\n      condition: { username: $username }\n      first: $first\n      orderBy: USERNAME_ASC\n    ) {\n      nodes {\n        id\n        rowId\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n': typeof types.AccountSearchDocument
   '\n    mutation CreateAccountBlock($input: CreateAccountBlockInput!) {\n      createAccountBlock(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.CreateAccountBlockDocument
   '\n    mutation DeleteAccountBlock(\n      $input: DeleteAccountBlockByCreatedByAndBlockedAccountIdInput!\n    ) {\n      deleteAccountBlockByCreatedByAndBlockedAccountId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteAccountBlockDocument
   '\n    query AttendanceGuest($id: UUID!) {\n      guestByRowId(rowId: $id) {\n        contactByContactId {\n          accountByAccountId {\n            id\n            rowId\n            username\n          }\n          firstName\n          id\n          lastName\n          language\n          nickname\n          rowId\n        }\n        attendanceByGuestId {\n          checkedOut\n          id\n          rowId\n          updatedAt\n        }\n        feedback\n        id\n        rowId\n      }\n    }\n  ': typeof types.AttendanceGuestDocument
-  '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllContactsDocument
   '\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteContactByRowIdDocument
+  '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllContactsDocument
   '\n  query AllLegalTerms($language: String) {\n    allLegalTerms(condition: { language: $language }) {\n      nodes {\n        id\n        rowId\n        term\n      }\n    }\n  }\n': typeof types.AllLegalTermsDocument
   '\n  query EventList($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: START_ASC) {\n      nodes {\n        accountByCreatedBy {\n          id\n          rowId\n          username\n        }\n        addressByAddressId {\n          id\n          location {\n            latitude\n            longitude\n          }\n          rowId\n        }\n        end\n        eventCategoryMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventCategoryByCategoryId {\n              name\n            }\n          }\n        }\n        eventFavoritesByEventId(first: 1) {\n          nodes {\n            id\n            createdBy\n            rowId\n          }\n        }\n        eventFormatMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventFormatByFormatId {\n              name\n            }\n          }\n        }\n        guestsByEventId(first: 1) {\n          nodes {\n            contactByContactId {\n              accountId\n              id\n              rowId\n            }\n            id\n            rowId\n          }\n        }\n        id\n        name\n        rowId\n        slug\n        start\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      totalCount\n    }\n  }\n': typeof types.EventListDocument
   '\n  query EventSearch(\n    $after: Cursor\n    $first: Int\n    $language: Language\n    $query: String\n  ) {\n    eventSearch(\n      after: $after\n      first: $first\n      language: $language\n      query: $query\n    ) {\n      nodes {\n        accountByCreatedBy {\n          id\n          rowId\n          username\n        }\n        addressByAddressId {\n          id\n          location {\n            latitude\n            longitude\n          }\n          rowId\n        }\n        end\n        eventCategoryMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventCategoryByCategoryId {\n              name\n            }\n          }\n        }\n        eventFavoritesByEventId(first: 1) {\n          nodes {\n            createdBy\n            id\n            rowId\n          }\n        }\n        eventFormatMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventFormatByFormatId {\n              name\n            }\n          }\n        }\n        guestsByEventId(first: 1) {\n          nodes {\n            contactByContactId {\n              accountId\n              id\n              rowId\n            }\n            id\n            rowId\n          }\n        }\n        id\n        name\n        rowId\n        slug\n        start\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      totalCount\n    }\n  }\n': typeof types.EventSearchDocument
@@ -42,9 +43,10 @@ type Documents = {
   '\n    mutation AccountPasswordChange($input: AccountPasswordChangeInput!) {\n      accountPasswordChange(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountPasswordChangeDocument
   '\n    mutation AccountPasswordReset($input: AccountPasswordResetInput!) {\n      accountPasswordReset(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountPasswordResetDocument
   '\n    mutation AccountPasswordResetRequest(\n      $input: AccountPasswordResetRequestInput!\n    ) {\n      accountPasswordResetRequest(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountPasswordResetRequestDocument
-  '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllGuestsDocument
   '\n    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {\n      deleteGuestByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteGuestByRowIdDocument
+  '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllGuestsDocument
   '\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.InviteDocument
+  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ': typeof types.UpdateGuestByRowIdFeedbackDocument
   '\n    query AllPreferenceEventSizes {\n      allPreferenceEventSizes {\n        nodes {\n          eventSize\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllPreferenceEventSizesDocument
   '\n    mutation CreatePreferenceEventSize(\n      $input: CreatePreferenceEventSizeInput!\n    ) {\n      createPreferenceEventSize(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.CreatePreferenceEventSizeDocument
   '\n    mutation DeletePreferenceEventSizeByAccountIdAndEventSize(\n      $input: DeletePreferenceEventSizeByAccountIdAndEventSizeInput!\n    ) {\n      deletePreferenceEventSizeByAccountIdAndEventSize(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeletePreferenceEventSizeByAccountIdAndEventSizeDocument
@@ -56,14 +58,13 @@ type Documents = {
   '\n    mutation DeletePreferenceEventFormatByAccountIdAndFormatId(\n      $input: DeletePreferenceEventFormatByAccountIdAndFormatIdInput!\n    ) {\n      deletePreferenceEventFormatByAccountIdAndFormatId(input: $input) {\n        deletedPreferenceEventFormatId\n      }\n    }\n  ': typeof types.DeletePreferenceEventFormatByAccountIdAndFormatIdDocument
   '\n    mutation CreatePreferenceEventLocation(\n      $input: CreatePreferenceEventLocationInput!\n    ) {\n      createPreferenceEventLocation(input: $input) {\n        preferenceEventLocation {\n          ...PreferenceEventLocationItem\n        }\n      }\n    }\n  ': typeof types.CreatePreferenceEventLocationDocument
   '\n    mutation DeletePreferenceEventLocationByRowId(\n      $input: DeletePreferenceEventLocationByRowIdInput!\n    ) {\n      deletePreferenceEventLocationByRowId(input: $input) {\n        deletedPreferenceEventLocationId\n      }\n    }\n  ': typeof types.DeletePreferenceEventLocationByRowIdDocument
+  '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteUploadByRowIdDocument
   '\n    query AccountUploadQuotaBytes {\n      accountUploadQuotaBytes\n    }\n  ': typeof types.AccountUploadQuotaBytesDocument
   '\n    query AllUploads($after: Cursor, $first: Int!, $createdBy: UUID) {\n      allUploads(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n      ) {\n        nodes {\n          id\n          rowId\n          sizeByte\n          storageKey\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllUploadsDocument
-  '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteUploadByRowIdDocument
   '\n    mutation CreateUpload($input: CreateUploadInput!) {\n      createUpload(input: $input) {\n        clientMutationId\n        upload {\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.CreateUploadDocument
   '\n    mutation JwtUpdateGuestAddGuest($input: JwtUpdateGuestAddInput!) {\n      jwtUpdateGuestAdd(input: $input) {\n        result\n      }\n    }\n  ': typeof types.JwtUpdateGuestAddGuestDocument
   '\n    query AccountEdit($username: String!) {\n      accountByUsername(username: $username) {\n        description\n        id\n        imprintUrl\n        profilePictureByAccountId {\n          id\n          rowId\n          uploadByUploadId {\n            id\n            rowId\n            storageKey\n          }\n        }\n        rowId\n        username\n      }\n    }\n  ': typeof types.AccountEditDocument
   '\n    mutation CreateProfilePicture($input: CreateProfilePictureInput!) {\n      createProfilePicture(input: $input) {\n        profilePicture {\n          accountByAccountId {\n            id\n            profilePictureByAccountId {\n              id\n              rowId\n            }\n            rowId\n          }\n          id\n          rowId\n          uploadId\n        }\n      }\n    }\n  ': typeof types.CreateProfilePictureDocument
-  '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteProfilePictureByRowIdMutationDocument
   '\n    mutation UpdateAccountByRowId($input: UpdateAccountByRowIdInput!) {\n      updateAccountByRowId(input: $input) {\n        account {\n          description\n          id\n          imprintUrl\n          rowId\n        }\n      }\n    }\n  ': typeof types.UpdateAccountByRowIdDocument
   '\n    mutation AccountEmailAddressVerification(\n      $input: AccountEmailAddressVerificationInput!\n    ) {\n      accountEmailAddressVerification(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.AccountEmailAddressVerificationDocument
   '\n    query AccountBlockAccounts {\n      accountBlockAccounts {\n        nodes {\n          id\n          storageKey\n          username\n        }\n      }\n    }\n  ': typeof types.AccountBlockAccountsDocument
@@ -109,6 +110,8 @@ const documents: Documents = {
     types.AccountDeleteDocument,
   '\n    query AccountByRowId($id: UUID!) {\n      accountByRowId(rowId: $id) {\n        id\n        profilePictureByAccountId {\n          id\n          rowId\n          uploadByUploadId {\n            id\n            rowId\n            storageKey\n          }\n        }\n        rowId\n        username\n      }\n    }\n  ':
     types.AccountByRowIdDocument,
+  '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
+    types.DeleteProfilePictureByRowIdMutationDocument,
   '\n  query AccountSearch($after: Cursor, $first: Int, $username: String) {\n    allAccounts(\n      after: $after\n      condition: { username: $username }\n      first: $first\n      orderBy: USERNAME_ASC\n    ) {\n      nodes {\n        id\n        rowId\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n':
     types.AccountSearchDocument,
   '\n    mutation CreateAccountBlock($input: CreateAccountBlockInput!) {\n      createAccountBlock(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
@@ -117,10 +120,10 @@ const documents: Documents = {
     types.DeleteAccountBlockDocument,
   '\n    query AttendanceGuest($id: UUID!) {\n      guestByRowId(rowId: $id) {\n        contactByContactId {\n          accountByAccountId {\n            id\n            rowId\n            username\n          }\n          firstName\n          id\n          lastName\n          language\n          nickname\n          rowId\n        }\n        attendanceByGuestId {\n          checkedOut\n          id\n          rowId\n          updatedAt\n        }\n        feedback\n        id\n        rowId\n      }\n    }\n  ':
     types.AttendanceGuestDocument,
-  '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ':
-    types.AllContactsDocument,
   '\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.DeleteContactByRowIdDocument,
+  '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ':
+    types.AllContactsDocument,
   '\n  query AllLegalTerms($language: String) {\n    allLegalTerms(condition: { language: $language }) {\n      nodes {\n        id\n        rowId\n        term\n      }\n    }\n  }\n':
     types.AllLegalTermsDocument,
   '\n  query EventList($after: Cursor, $first: Int!) {\n    allEvents(after: $after, first: $first, orderBy: START_ASC) {\n      nodes {\n        accountByCreatedBy {\n          id\n          rowId\n          username\n        }\n        addressByAddressId {\n          id\n          location {\n            latitude\n            longitude\n          }\n          rowId\n        }\n        end\n        eventCategoryMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventCategoryByCategoryId {\n              name\n            }\n          }\n        }\n        eventFavoritesByEventId(first: 1) {\n          nodes {\n            id\n            createdBy\n            rowId\n          }\n        }\n        eventFormatMappingsByEventId(first: 1, orderBy: PRIMARY_KEY_ASC) {\n          nodes {\n            eventFormatByFormatId {\n              name\n            }\n          }\n        }\n        guestsByEventId(first: 1) {\n          nodes {\n            contactByContactId {\n              accountId\n              id\n              rowId\n            }\n            id\n            rowId\n          }\n        }\n        id\n        name\n        rowId\n        slug\n        start\n      }\n      pageInfo {\n        hasNextPage\n        endCursor\n      }\n      totalCount\n    }\n  }\n':
@@ -161,12 +164,14 @@ const documents: Documents = {
     types.AccountPasswordResetDocument,
   '\n    mutation AccountPasswordResetRequest(\n      $input: AccountPasswordResetRequestInput!\n    ) {\n      accountPasswordResetRequest(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.AccountPasswordResetRequestDocument,
-  '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ':
-    types.AllGuestsDocument,
   '\n    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {\n      deleteGuestByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.DeleteGuestByRowIdDocument,
+  '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ':
+    types.AllGuestsDocument,
   '\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.InviteDocument,
+  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ':
+    types.UpdateGuestByRowIdFeedbackDocument,
   '\n    query AllPreferenceEventSizes {\n      allPreferenceEventSizes {\n        nodes {\n          eventSize\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.AllPreferenceEventSizesDocument,
   '\n    mutation CreatePreferenceEventSize(\n      $input: CreatePreferenceEventSizeInput!\n    ) {\n      createPreferenceEventSize(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
@@ -189,12 +194,12 @@ const documents: Documents = {
     types.CreatePreferenceEventLocationDocument,
   '\n    mutation DeletePreferenceEventLocationByRowId(\n      $input: DeletePreferenceEventLocationByRowIdInput!\n    ) {\n      deletePreferenceEventLocationByRowId(input: $input) {\n        deletedPreferenceEventLocationId\n      }\n    }\n  ':
     types.DeletePreferenceEventLocationByRowIdDocument,
+  '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
+    types.DeleteUploadByRowIdDocument,
   '\n    query AccountUploadQuotaBytes {\n      accountUploadQuotaBytes\n    }\n  ':
     types.AccountUploadQuotaBytesDocument,
   '\n    query AllUploads($after: Cursor, $first: Int!, $createdBy: UUID) {\n      allUploads(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n      ) {\n        nodes {\n          id\n          rowId\n          sizeByte\n          storageKey\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ':
     types.AllUploadsDocument,
-  '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
-    types.DeleteUploadByRowIdDocument,
   '\n    mutation CreateUpload($input: CreateUploadInput!) {\n      createUpload(input: $input) {\n        clientMutationId\n        upload {\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.CreateUploadDocument,
   '\n    mutation JwtUpdateGuestAddGuest($input: JwtUpdateGuestAddInput!) {\n      jwtUpdateGuestAdd(input: $input) {\n        result\n      }\n    }\n  ':
@@ -203,8 +208,6 @@ const documents: Documents = {
     types.AccountEditDocument,
   '\n    mutation CreateProfilePicture($input: CreateProfilePictureInput!) {\n      createProfilePicture(input: $input) {\n        profilePicture {\n          accountByAccountId {\n            id\n            profilePictureByAccountId {\n              id\n              rowId\n            }\n            rowId\n          }\n          id\n          rowId\n          uploadId\n        }\n      }\n    }\n  ':
     types.CreateProfilePictureDocument,
-  '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
-    types.DeleteProfilePictureByRowIdMutationDocument,
   '\n    mutation UpdateAccountByRowId($input: UpdateAccountByRowIdInput!) {\n      updateAccountByRowId(input: $input) {\n        account {\n          description\n          id\n          imprintUrl\n          rowId\n        }\n      }\n    }\n  ':
     types.UpdateAccountByRowIdDocument,
   '\n    mutation AccountEmailAddressVerification(\n      $input: AccountEmailAddressVerificationInput!\n    ) {\n      accountEmailAddressVerification(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
@@ -315,6 +318,12 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: '\n  query AccountSearch($after: Cursor, $first: Int, $username: String) {\n    allAccounts(\n      after: $after\n      condition: { username: $username }\n      first: $first\n      orderBy: USERNAME_ASC\n    ) {\n      nodes {\n        id\n        rowId\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n',
 ): (typeof documents)['\n  query AccountSearch($after: Cursor, $first: Int, $username: String) {\n    allAccounts(\n      after: $after\n      condition: { username: $username }\n      first: $first\n      orderBy: USERNAME_ASC\n    ) {\n      nodes {\n        id\n        rowId\n        username\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n']
 /**
@@ -339,14 +348,14 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ',
-): (typeof documents)['\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ']
+  source: '\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation DeleteContactByRowId($input: DeleteContactByRowIdInput!) {\n      deleteContactByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
+  source: '\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ',
+): (typeof documents)['\n    query AllContacts($after: Cursor, $createdBy: UUID, $first: Int!) {\n      allContacts(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n        orderBy: [FIRST_NAME_ASC, LAST_NAME_ASC]\n      ) {\n        nodes {\n          ...ContactItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -471,20 +480,26 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ',
-): (typeof documents)['\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ']
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
   source: '\n    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {\n      deleteGuestByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
 ): (typeof documents)['\n    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {\n      deleteGuestByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ',
+): (typeof documents)['\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: '\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
 ): (typeof documents)['\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
+  source: '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -555,6 +570,12 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
+  source: '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(
   source: '\n    query AccountUploadQuotaBytes {\n      accountUploadQuotaBytes\n    }\n  ',
 ): (typeof documents)['\n    query AccountUploadQuotaBytes {\n      accountUploadQuotaBytes\n    }\n  ']
 /**
@@ -563,12 +584,6 @@ export function graphql(
 export function graphql(
   source: '\n    query AllUploads($after: Cursor, $first: Int!, $createdBy: UUID) {\n      allUploads(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n      ) {\n        nodes {\n          id\n          rowId\n          sizeByte\n          storageKey\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ',
 ): (typeof documents)['\n    query AllUploads($after: Cursor, $first: Int!, $createdBy: UUID) {\n      allUploads(\n        after: $after\n        condition: { createdBy: $createdBy }\n        first: $first\n      ) {\n        nodes {\n          id\n          rowId\n          sizeByte\n          storageKey\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ']
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: '\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation DeleteUploadByRowId($input: DeleteUploadByRowIdInput!) {\n      deleteUploadByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
@@ -593,12 +608,6 @@ export function graphql(
 export function graphql(
   source: '\n    mutation CreateProfilePicture($input: CreateProfilePictureInput!) {\n      createProfilePicture(input: $input) {\n        profilePicture {\n          accountByAccountId {\n            id\n            profilePictureByAccountId {\n              id\n              rowId\n            }\n            rowId\n          }\n          id\n          rowId\n          uploadId\n        }\n      }\n    }\n  ',
 ): (typeof documents)['\n    mutation CreateProfilePicture($input: CreateProfilePictureInput!) {\n      createProfilePicture(input: $input) {\n        profilePicture {\n          accountByAccountId {\n            id\n            profilePictureByAccountId {\n              id\n              rowId\n            }\n            rowId\n          }\n          id\n          rowId\n          uploadId\n        }\n      }\n    }\n  ']
-/**
- * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
- */
-export function graphql(
-  source: '\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation DeleteProfilePictureByRowIdMutation(\n      $input: DeleteProfilePictureByRowIdInput!\n    ) {\n      deleteProfilePictureByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -849,6 +849,14 @@ export type AccountByRowIdQuery = {
   } | null
 }
 
+export type DeleteProfilePictureByRowIdMutationMutationVariables = Exact<{
+  input: DeleteProfilePictureByRowIdInput
+}>
+
+export type DeleteProfilePictureByRowIdMutationMutation = {
+  deleteProfilePictureByRowId: { clientMutationId: string | null } | null
+}
+
 export type AccountSearchQueryVariables = Exact<{
   after?: string | null | undefined
   first?: number | null | undefined
@@ -907,6 +915,14 @@ export type AttendanceGuestQuery = {
   } | null
 }
 
+export type DeleteContactByRowIdMutationVariables = Exact<{
+  input: DeleteContactByRowIdInput
+}>
+
+export type DeleteContactByRowIdMutation = {
+  deleteContactByRowId: { clientMutationId: string | null } | null
+}
+
 export type AllContactsQueryVariables = Exact<{
   after?: string | null | undefined
   createdBy?: string | null | undefined
@@ -921,14 +937,6 @@ export type AllContactsQuery = {
     }>
     pageInfo: { hasNextPage: boolean; endCursor: string | null }
   } | null
-}
-
-export type DeleteContactByRowIdMutationVariables = Exact<{
-  input: DeleteContactByRowIdInput
-}>
-
-export type DeleteContactByRowIdMutation = {
-  deleteContactByRowId: { clientMutationId: string | null } | null
 }
 
 export type AllLegalTermsQueryVariables = Exact<{
@@ -1207,6 +1215,14 @@ export type AccountPasswordResetRequestMutation = {
   accountPasswordResetRequest: { clientMutationId: string | null } | null
 }
 
+export type DeleteGuestByRowIdMutationVariables = Exact<{
+  input: DeleteGuestByRowIdInput
+}>
+
+export type DeleteGuestByRowIdMutation = {
+  deleteGuestByRowId: { clientMutationId: string | null } | null
+}
+
 export type AllGuestsQueryVariables = Exact<{
   after?: string | null | undefined
   eventId: string
@@ -1223,20 +1239,22 @@ export type AllGuestsQuery = {
   } | null
 }
 
-export type DeleteGuestByRowIdMutationVariables = Exact<{
-  input: DeleteGuestByRowIdInput
-}>
-
-export type DeleteGuestByRowIdMutation = {
-  deleteGuestByRowId: { clientMutationId: string | null } | null
-}
-
 export type InviteMutationVariables = Exact<{
   input: InviteInput
 }>
 
 export type InviteMutation = {
   invite: { clientMutationId: string | null } | null
+}
+
+export type UpdateGuestByRowIdFeedbackMutationVariables = Exact<{
+  input: UpdateGuestByRowIdInput
+}>
+
+export type UpdateGuestByRowIdFeedbackMutation = {
+  updateGuestByRowId: {
+    guest: { feedback: InvitationFeedback | null; id: string } | null
+  } | null
 }
 
 export type AllPreferenceEventSizesQueryVariables = Exact<{
@@ -1358,6 +1376,14 @@ export type DeletePreferenceEventLocationByRowIdMutation = {
   } | null
 }
 
+export type DeleteUploadByRowIdMutationVariables = Exact<{
+  input: DeleteUploadByRowIdInput
+}>
+
+export type DeleteUploadByRowIdMutation = {
+  deleteUploadByRowId: { clientMutationId: string | null } | null
+}
+
 export type AccountUploadQuotaBytesQueryVariables = Exact<{
   [key: string]: never
 }>
@@ -1383,14 +1409,6 @@ export type AllUploadsQuery = {
     }>
     pageInfo: { hasNextPage: boolean; endCursor: string | null }
   } | null
-}
-
-export type DeleteUploadByRowIdMutationVariables = Exact<{
-  input: DeleteUploadByRowIdInput
-}>
-
-export type DeleteUploadByRowIdMutation = {
-  deleteUploadByRowId: { clientMutationId: string | null } | null
 }
 
 export type CreateUploadMutationVariables = Exact<{
@@ -1452,14 +1470,6 @@ export type CreateProfilePictureMutation = {
       } | null
     } | null
   } | null
-}
-
-export type DeleteProfilePictureByRowIdMutationMutationVariables = Exact<{
-  input: DeleteProfilePictureByRowIdInput
-}>
-
-export type DeleteProfilePictureByRowIdMutationMutation = {
-  deleteProfilePictureByRowId: { clientMutationId: string | null } | null
 }
 
 export type UpdateAccountByRowIdMutationVariables = Exact<{
@@ -2646,6 +2656,63 @@ export const AccountByRowIdDocument = {
     },
   ],
 } as unknown as DocumentNode<AccountByRowIdQuery, AccountByRowIdQueryVariables>
+export const DeleteProfilePictureByRowIdMutationDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'DeleteProfilePictureByRowIdMutation' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'DeleteProfilePictureByRowIdInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'deleteProfilePictureByRowId' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'clientMutationId' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteProfilePictureByRowIdMutationMutation,
+  DeleteProfilePictureByRowIdMutationMutationVariables
+>
 export const AccountSearchDocument = {
   kind: 'Document',
   definitions: [
@@ -3005,6 +3072,63 @@ export const AttendanceGuestDocument = {
   AttendanceGuestQuery,
   AttendanceGuestQueryVariables
 >
+export const DeleteContactByRowIdDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'DeleteContactByRowId' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'DeleteContactByRowIdInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'deleteContactByRowId' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'clientMutationId' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteContactByRowIdMutation,
+  DeleteContactByRowIdMutationVariables
+>
 export const AllContactsDocument = {
   kind: 'Document',
   definitions: [
@@ -3184,63 +3308,6 @@ export const AllContactsDocument = {
     },
   ],
 } as unknown as DocumentNode<AllContactsQuery, AllContactsQueryVariables>
-export const DeleteContactByRowIdDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'mutation',
-      name: { kind: 'Name', value: 'DeleteContactByRowId' },
-      variableDefinitions: [
-        {
-          kind: 'VariableDefinition',
-          variable: {
-            kind: 'Variable',
-            name: { kind: 'Name', value: 'input' },
-          },
-          type: {
-            kind: 'NonNullType',
-            type: {
-              kind: 'NamedType',
-              name: { kind: 'Name', value: 'DeleteContactByRowIdInput' },
-            },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'deleteContactByRowId' },
-            arguments: [
-              {
-                kind: 'Argument',
-                name: { kind: 'Name', value: 'input' },
-                value: {
-                  kind: 'Variable',
-                  name: { kind: 'Name', value: 'input' },
-                },
-              },
-            ],
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'clientMutationId' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<
-  DeleteContactByRowIdMutation,
-  DeleteContactByRowIdMutationVariables
->
 export const AllLegalTermsDocument = {
   kind: 'Document',
   definitions: [
@@ -5212,6 +5279,63 @@ export const AccountPasswordResetRequestDocument = {
   AccountPasswordResetRequestMutation,
   AccountPasswordResetRequestMutationVariables
 >
+export const DeleteGuestByRowIdDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'DeleteGuestByRowId' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'DeleteGuestByRowIdInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'deleteGuestByRowId' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'clientMutationId' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteGuestByRowIdMutation,
+  DeleteGuestByRowIdMutationVariables
+>
 export const AllGuestsDocument = {
   kind: 'Document',
   definitions: [
@@ -5413,63 +5537,6 @@ export const AllGuestsDocument = {
     },
   ],
 } as unknown as DocumentNode<AllGuestsQuery, AllGuestsQueryVariables>
-export const DeleteGuestByRowIdDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'mutation',
-      name: { kind: 'Name', value: 'DeleteGuestByRowId' },
-      variableDefinitions: [
-        {
-          kind: 'VariableDefinition',
-          variable: {
-            kind: 'Variable',
-            name: { kind: 'Name', value: 'input' },
-          },
-          type: {
-            kind: 'NonNullType',
-            type: {
-              kind: 'NamedType',
-              name: { kind: 'Name', value: 'DeleteGuestByRowIdInput' },
-            },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'deleteGuestByRowId' },
-            arguments: [
-              {
-                kind: 'Argument',
-                name: { kind: 'Name', value: 'input' },
-                value: {
-                  kind: 'Variable',
-                  name: { kind: 'Name', value: 'input' },
-                },
-              },
-            ],
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'clientMutationId' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<
-  DeleteGuestByRowIdMutation,
-  DeleteGuestByRowIdMutationVariables
->
 export const InviteDocument = {
   kind: 'Document',
   definitions: [
@@ -5524,6 +5591,73 @@ export const InviteDocument = {
     },
   ],
 } as unknown as DocumentNode<InviteMutation, InviteMutationVariables>
+export const UpdateGuestByRowIdFeedbackDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'UpdateGuestByRowIdFeedback' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'UpdateGuestByRowIdInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'updateGuestByRowId' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'guest' },
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'feedback' },
+                      },
+                      { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  UpdateGuestByRowIdFeedbackMutation,
+  UpdateGuestByRowIdFeedbackMutationVariables
+>
 export const AllPreferenceEventSizesDocument = {
   kind: 'Document',
   definitions: [
@@ -6242,6 +6376,63 @@ export const DeletePreferenceEventLocationByRowIdDocument = {
   DeletePreferenceEventLocationByRowIdMutation,
   DeletePreferenceEventLocationByRowIdMutationVariables
 >
+export const DeleteUploadByRowIdDocument = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'mutation',
+      name: { kind: 'Name', value: 'DeleteUploadByRowId' },
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {
+            kind: 'Variable',
+            name: { kind: 'Name', value: 'input' },
+          },
+          type: {
+            kind: 'NonNullType',
+            type: {
+              kind: 'NamedType',
+              name: { kind: 'Name', value: 'DeleteUploadByRowIdInput' },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: 'deleteUploadByRowId' },
+            arguments: [
+              {
+                kind: 'Argument',
+                name: { kind: 'Name', value: 'input' },
+                value: {
+                  kind: 'Variable',
+                  name: { kind: 'Name', value: 'input' },
+                },
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: { kind: 'Name', value: 'clientMutationId' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteUploadByRowIdMutation,
+  DeleteUploadByRowIdMutationVariables
+>
 export const AccountUploadQuotaBytesDocument = {
   kind: 'Document',
   definitions: [
@@ -6389,63 +6580,6 @@ export const AllUploadsDocument = {
     },
   ],
 } as unknown as DocumentNode<AllUploadsQuery, AllUploadsQueryVariables>
-export const DeleteUploadByRowIdDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'mutation',
-      name: { kind: 'Name', value: 'DeleteUploadByRowId' },
-      variableDefinitions: [
-        {
-          kind: 'VariableDefinition',
-          variable: {
-            kind: 'Variable',
-            name: { kind: 'Name', value: 'input' },
-          },
-          type: {
-            kind: 'NonNullType',
-            type: {
-              kind: 'NamedType',
-              name: { kind: 'Name', value: 'DeleteUploadByRowIdInput' },
-            },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'deleteUploadByRowId' },
-            arguments: [
-              {
-                kind: 'Argument',
-                name: { kind: 'Name', value: 'input' },
-                value: {
-                  kind: 'Variable',
-                  name: { kind: 'Name', value: 'input' },
-                },
-              },
-            ],
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'clientMutationId' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<
-  DeleteUploadByRowIdMutation,
-  DeleteUploadByRowIdMutationVariables
->
 export const CreateUploadDocument = {
   kind: 'Document',
   definitions: [
@@ -6759,63 +6893,6 @@ export const CreateProfilePictureDocument = {
 } as unknown as DocumentNode<
   CreateProfilePictureMutation,
   CreateProfilePictureMutationVariables
->
-export const DeleteProfilePictureByRowIdMutationDocument = {
-  kind: 'Document',
-  definitions: [
-    {
-      kind: 'OperationDefinition',
-      operation: 'mutation',
-      name: { kind: 'Name', value: 'DeleteProfilePictureByRowIdMutation' },
-      variableDefinitions: [
-        {
-          kind: 'VariableDefinition',
-          variable: {
-            kind: 'Variable',
-            name: { kind: 'Name', value: 'input' },
-          },
-          type: {
-            kind: 'NonNullType',
-            type: {
-              kind: 'NamedType',
-              name: { kind: 'Name', value: 'DeleteProfilePictureByRowIdInput' },
-            },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: 'SelectionSet',
-        selections: [
-          {
-            kind: 'Field',
-            name: { kind: 'Name', value: 'deleteProfilePictureByRowId' },
-            arguments: [
-              {
-                kind: 'Argument',
-                name: { kind: 'Name', value: 'input' },
-                value: {
-                  kind: 'Variable',
-                  name: { kind: 'Name', value: 'input' },
-                },
-              },
-            ],
-            selectionSet: {
-              kind: 'SelectionSet',
-              selections: [
-                {
-                  kind: 'Field',
-                  name: { kind: 'Name', value: 'clientMutationId' },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<
-  DeleteProfilePictureByRowIdMutationMutation,
-  DeleteProfilePictureByRowIdMutationMutationVariables
 >
 export const UpdateAccountByRowIdDocument = {
   kind: 'Document',


### PR DESCRIPTION
When an organizer previewed a guest's invitation link, they could use the same accept/decline buttons the guest uses, which was confusing since it looked like a normal RSVP action but actually overrode the guest's response. The invitation page now shows a read-only status to the organizer, and the accept/decline override is available as actions in the guest list dropdown instead.

Closes #2384