### PR TITLE
feat(guest): add list search and alphabetical ordering

### DIFF
--- a/src/app/components/guest/GuestList.vue
+++ b/src/app/components/guest/GuestList.vue
@@ -26,21 +26,27 @@
         </p>
       </div>
       <template v-if="event && guests.length">
-        <Select v-model="feedbackFilter">
-          <SelectTrigger :aria-label="t('feedbackFilter')" class="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">{{ t('feedbackFilterAll') }}</SelectItem>
-            <SelectItem :value="InvitationFeedback.Accepted">
-              {{ t('accepted') }}
-            </SelectItem>
-            <SelectItem :value="InvitationFeedback.Canceled">
-              {{ t('canceled') }}
-            </SelectItem>
-            <SelectItem value="none">{{ t('noFeedback') }}</SelectItem>
-          </SelectContent>
-        </Select>
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <FormInputSearch v-model="searchString" class="flex-1" />
+          <Select v-model="feedbackFilter">
+            <SelectTrigger
+              :aria-label="t('feedbackFilter')"
+              class="w-full sm:w-56"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{{ t('feedbackFilterAll') }}</SelectItem>
+              <SelectItem :value="InvitationFeedback.Accepted">
+                {{ t('accepted') }}
+              </SelectItem>
+              <SelectItem :value="InvitationFeedback.Canceled">
+                {{ t('canceled') }}
+              </SelectItem>
+              <SelectItem value="none">{{ t('noFeedback') }}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <LayoutTable
           v-if="guestsFiltered.length"
           class="border border-neutral-300 dark:border-neutral-600"
@@ -138,7 +144,9 @@ import { InvitationFeedback } from '~~/gql/generated/graphcache'
 import type {
   AllGuestsQueryVariables,
   EventItemFragment,
+  GuestItemFragment,
 } from '~~/gql/generated/graphql'
+import { getContactItem } from '~~/shared/utils/contact'
 import { getGuestItem } from '~~/shared/utils/guest'
 
 const { event } = defineProps<{
@@ -157,6 +165,7 @@ const templateDoughnut = useTemplateRef<DoughnutController>('doughnut')
 const after = ref<string | null>()
 const feedbackFilter = ref<string>('all')
 const isModalGuestOpen = ref<boolean>()
+const searchString = ref<string>('')
 const options = {
   plugins: {
     legend: {
@@ -254,22 +263,39 @@ const dataComputed = computed(() => {
     ],
   }
 })
+const getGuestContactName = (
+  guest: Pick<GuestItemFragment, 'contactByContactId'>,
+) => {
+  const contact = getContactItem(guest.contactByContactId)
+  return [contact?.firstName, contact?.lastName].filter(Boolean).join(' ')
+}
 const guests = computed(
   () =>
     api.value.data.allGuests?.nodes
       .map((x) => getGuestItem(x))
-      .filter(isNeitherNullNorUndefined) || [],
+      .filter(isNeitherNullNorUndefined)
+      .sort((a, b) =>
+        getGuestContactName(a).localeCompare(getGuestContactName(b)),
+      ) || [],
 )
 const guestsFiltered = computed(() => {
+  const normalizedSearch = searchString.value.toLowerCase().trim()
+  const searchStringParts = normalizedSearch.split(/\s+/).filter(Boolean)
+  const bySearch = searchStringParts.length
+    ? guests.value.filter((guest) =>
+        searchStringParts.some((searchStringPart) =>
+          getGuestContactName(guest).toLowerCase().includes(searchStringPart),
+        ),
+      )
+    : guests.value
+
   switch (feedbackFilter.value) {
     case 'all':
-      return guests.value
+      return bySearch
     case 'none':
-      return guests.value.filter((guest) => guest.feedback === null)
+      return bySearch.filter((guest) => guest.feedback === null)
     default:
-      return guests.value.filter(
-        (guest) => guest.feedback === feedbackFilter.value,
-      )
+      return bySearch.filter((guest) => guest.feedback === feedbackFilter.value)
   }
 })
 

--- a/src/app/components/guest/GuestListItem.vue
+++ b/src/app/components/guest/GuestListItem.vue
@@ -186,6 +186,7 @@ const updateGuestByRowIdMutation = useMutation(
         guest {
           feedback
           id
+          rowId
         }
       }
     }

--- a/src/gql/generated/gql.ts
+++ b/src/gql/generated/gql.ts
@@ -46,7 +46,7 @@ type Documents = {
   '\n    mutation DeleteGuestByRowId($input: DeleteGuestByRowIdInput!) {\n      deleteGuestByRowId(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeleteGuestByRowIdDocument
   '\n    query AllGuests($after: Cursor, $eventId: UUID!, $first: Int!) {\n      allGuests(\n        after: $after\n        condition: { eventId: $eventId }\n        first: $first\n      ) {\n        nodes {\n          ...GuestItem\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n        totalCount\n      }\n    }\n  ': typeof types.AllGuestsDocument
   '\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.InviteDocument
-  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ': typeof types.UpdateGuestByRowIdFeedbackDocument
+  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.UpdateGuestByRowIdFeedbackDocument
   '\n    query AllPreferenceEventSizes {\n      allPreferenceEventSizes {\n        nodes {\n          eventSize\n          id\n          rowId\n        }\n      }\n    }\n  ': typeof types.AllPreferenceEventSizesDocument
   '\n    mutation CreatePreferenceEventSize(\n      $input: CreatePreferenceEventSizeInput!\n    ) {\n      createPreferenceEventSize(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.CreatePreferenceEventSizeDocument
   '\n    mutation DeletePreferenceEventSizeByAccountIdAndEventSize(\n      $input: DeletePreferenceEventSizeByAccountIdAndEventSizeInput!\n    ) {\n      deletePreferenceEventSizeByAccountIdAndEventSize(input: $input) {\n        clientMutationId\n      }\n    }\n  ': typeof types.DeletePreferenceEventSizeByAccountIdAndEventSizeDocument
@@ -170,7 +170,7 @@ const documents: Documents = {
     types.AllGuestsDocument,
   '\n    mutation Invite($input: InviteInput!) {\n      invite(input: $input) {\n        clientMutationId\n      }\n    }\n  ':
     types.InviteDocument,
-  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ':
+  '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.UpdateGuestByRowIdFeedbackDocument,
   '\n    query AllPreferenceEventSizes {\n      allPreferenceEventSizes {\n        nodes {\n          eventSize\n          id\n          rowId\n        }\n      }\n    }\n  ':
     types.AllPreferenceEventSizesDocument,
@@ -498,8 +498,8 @@ export function graphql(
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(
-  source: '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ',
-): (typeof documents)['\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n        }\n      }\n    }\n  ']
+  source: '\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n          rowId\n        }\n      }\n    }\n  ',
+): (typeof documents)['\n    mutation UpdateGuestByRowIdFeedback($input: UpdateGuestByRowIdInput!) {\n      updateGuestByRowId(input: $input) {\n        guest {\n          feedback\n          id\n          rowId\n        }\n      }\n    }\n  ']
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1253,7 +1253,11 @@ export type UpdateGuestByRowIdFeedbackMutationVariables = Exact<{
 
 export type UpdateGuestByRowIdFeedbackMutation = {
   updateGuestByRowId: {
-    guest: { feedback: InvitationFeedback | null; id: string } | null
+    guest: {
+      feedback: InvitationFeedback | null
+      id: string
+      rowId: string
+    } | null
   } | null
 }
 
@@ -5644,6 +5648,7 @@ export const UpdateGuestByRowIdFeedbackDocument = {
                         name: { kind: 'Name', value: 'feedback' },
                       },
                       { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                      { kind: 'Field', name: { kind: 'Name', value: 'rowId' } },
                     ],
                   },
                 },


### PR DESCRIPTION
Add a text search and alphabetical ordering to the guest list, matching contact list UX.

Also fixes a bug where an organizer changing a guest's RSVP feedback wasn't reflected in the guest's feedback icon: the update mutation only returned `feedback` and `id`, but the urql cache keys `Guest` entities by `rowId`, so the mutation result couldn't be merged into the cached entity.