### PR TITLE
chore(jwt): suffix cookie name in fullstack development

### DIFF
--- a/src/node/static/index.ts
+++ b/src/node/static/index.ts
@@ -1,6 +1,6 @@
 import { DEFAULTS } from '@dargmuesli/nuxt-cookie-control/runtime/types.js'
 
-import { SITE_URL_TYPED } from './environment.ts'
+import { IS_IN_STACK, SITE_URL_TYPED } from './environment.ts'
 import { getIsSecure, SITE_NAME } from './site.ts'
 
 export * from './environment.ts'
@@ -16,9 +16,11 @@ export const FEATURE_FLAGS_COOKIE_ID = 'f'
 export const FEATURE_FLAGS_COOKIE_NAME = `${SITE_NAME}_feature-flags`
 export const GTAG_COOKIE_ID = 'ga'
 export const GTAG_MEASUREMENT_ID = 'G-WMQ1JY99XH'
-export const JWT_COOKIE_NAME = `${getIsSecure({ siteUrl: SITE_URL_TYPED }) ? '__Host-' : ''}jwt-v3`
 export const POLYFILLS = ['Promise', 'requestAnimationFrame']
 export const PRODUCTION_HOST = 'vibetype.app'
+// suffixed in fullstack development so its cookie can't collide with frontend-only development's, since both run on the same local host;
+// keyed off the site's hostname rather than `NODE_ENV` because Nitro bakes `NODE_ENV` into the built server bundle at build time, so it would otherwise stay `production` forever regardless of where that build later runs
+export const JWT_COOKIE_NAME = `${getIsSecure({ siteUrl: SITE_URL_TYPED }) ? '__Host-' : ''}jwt-v3${IS_IN_STACK && SITE_URL_TYPED.hostname !== PRODUCTION_HOST ? '-local' : ''}`
 export const TESTING_COOKIE_NAME = `${SITE_NAME}_is-testing`
 export const THEME_COLOR = '#ffffff'
 export const TIMEZONE_COOKIE_NAME = 'm_tz'


### PR DESCRIPTION
Frontend-only development and fullstack development both run on the same local host (`app.localhost`), so the JWT cookie set while pointed at one backend was indistinguishable from, and silently reused by, the other, causing spurious authentication failures since the two backends sign JWTs with different keys. The cookie name is now suffixed with `-local` in fullstack development so the two cookies can no longer collide.