### PR TITLE
fix(redis): log connection errors once per outage instead of once per retry

### DIFF
--- a/src/server/plugins/redis.ts
+++ b/src/server/plugins/redis.ts
@@ -2,11 +2,18 @@ export default defineNitroPlugin((nitroApp) => {
   if (!IS_IN_STACK) return
 
   const redis = getRedisClient()
+  let hasLoggedConnectionError = false
 
-  redis.on('error', (error: Error) =>
-    console.error(`Redis connection error: ${error.message}`),
-  )
-  redis.on('connect', () => console.info('Redis connected'))
+  redis.on('error', (error: Error) => {
+    console[hasLoggedConnectionError ? 'debug' : 'error'](
+      `Redis connection error: ${error.message}`,
+    )
+    hasLoggedConnectionError = true
+  })
+  redis.on('connect', () => {
+    hasLoggedConnectionError = false
+    console.info('Redis connected')
+  })
 
   nitroApp.hooks.hookOnce('close', async () => {
     await redis.quit()


### PR DESCRIPTION
This pull request improves the logging behavior for Redis connection errors in the `src/server/plugins/redis.ts` file. The update ensures that only the first Redis connection error is logged as an error, while subsequent errors are logged as debug messages until a successful reconnect, which resets the logging level.

Logging improvements for Redis connection errors:

* Changed the Redis error event handler to log the first connection error as an error and subsequent errors as debug messages, resetting back to error logging after a successful connection. This prevents flooding the logs with repeated error messages.