### PR TITLE
chore(seo): remove deprecated twitter tags

### DIFF
--- a/src/app/composables/head.ts
+++ b/src/app/composables/head.ts
@@ -92,10 +92,9 @@ export const useHeadDefault = (
       ? {
           description,
           ogDescription: description,
-          twitterDescription: description,
         }
       : {}),
-    ...(title ? { title, ogTitle: title, twitterTitle: title } : {}),
+    ...(title ? { title, ogTitle: title } : {}),
     ...input,
   })
   defineOgImage(

--- a/tests/e2e/utils/tests.ts
+++ b/tests/e2e/utils/tests.ts
@@ -416,28 +416,8 @@ export const testMetadata = async ({
       tag: 'meta',
       attributes: [
         {
-          key: 'name',
-          value: 'twitter:description',
-        },
-        { key: 'content', value: 'Find events, guests and friends 💙❤️💚' },
-      ],
-    },
-    {
-      tag: 'meta',
-      attributes: [
-        {
           key: 'property',
           value: 'og:title',
-        },
-        { key: 'content', value: title },
-      ],
-    },
-    {
-      tag: 'meta',
-      attributes: [
-        {
-          key: 'name',
-          value: 'twitter:title',
         },
         { key: 'content', value: title },
       ],


### PR DESCRIPTION
This pull request makes a minor adjustment to the `useHeadDefault` composable by removing the `twitterDescription` and `twitterTitle` properties from the returned metadata object, as X now doesn't seem to use them anymore.