### PR TITLE
fix(event): avoid duplicate requests when opening the list

### DIFF
--- a/src/app/components/event/EventSearch.vue
+++ b/src/app/components/event/EventSearch.vue
@@ -192,6 +192,7 @@ const searchResultsQuery = useQuery({
     query: searchQueryVariable.value,
     first: ITEMS_PER_PAGE,
   })),
+  pause: computed(() => !searchQueryVariable.value),
 })
 const query = computed(() =>
   searchQueryVariable.value ? searchResultsQuery : allEventsQuery,
@@ -226,10 +227,20 @@ const events = computed(() => {
   return undefined
 })
 
+// Tracks whether the initial `advanceUntilUpcomingEvent` catch-up has
+// finished, so `loadMore` only switches `allEventsQueryFirst` back down to
+// `ITEMS_PER_PAGE` once there's also a new `after` cursor to go with it -
+// changing `allEventsQueryFirst` on its own would re-execute `allEventsQuery`
+// with the same `after` cursor, refetching (and discarding) data it already
+// has.
+let allEventsCaughtUpOnUpcomingEvent = false
+
 const loadMore = () => {
   if (!query.value.data.value) return
 
   if ('allEvents' in query.value.data.value) {
+    if (allEventsCaughtUpOnUpcomingEvent)
+      allEventsQueryFirst.value = ITEMS_PER_PAGE
     allEventsQueryAfter.value =
       query.value.data.value?.allEvents?.pageInfo.endCursor
   }
@@ -255,6 +266,13 @@ const advanceUntilUpcomingEvent = async () => {
   let pages = 0
   let previousEndCursor: string | null | undefined
 
+  // On the client (unlike during SSR, see below), the query triggered by
+  // `useQuery` at setup is still in flight at this point, so `events.value`
+  // reads as `undefined` rather than an empty array; awaiting the query here
+  // lets the loop condition below see its actual result instead of exiting
+  // immediately.
+  await query.value
+
   while (events.value?.length === 0 && pageInfo.value?.hasNextPage) {
     if (pages >= ADVANCE_UNTIL_UPCOMING_EVENT_MAX_PAGES) break
     // `hasNextPage` being true with an `endCursor` that isn't moving would
@@ -272,7 +290,7 @@ const advanceUntilUpcomingEvent = async () => {
 // makes the initial catch-up finish during server-side rendering instead of
 // flashing an empty list on load.
 await advanceUntilUpcomingEvent()
-allEventsQueryFirst.value = ITEMS_PER_PAGE
+allEventsCaughtUpOnUpcomingEvent = true
 
 watch(searchQueryVariable, async () => {
   searchResultsQueryAfter.value = undefined


### PR DESCRIPTION
Navigating to `/event` fired the events-list query twice (once with a large batch to page past ended events, then again with the normal page size after the first request had already returned or been aborted), and fired the search query on every load even though no search term was entered. Both were unnecessary network round trips that also raced with each other.