### PR TITLE
fix(error): show localized status and gate stack trace to dev

### DIFF
--- a/src/app/components/app/AppError.vue
+++ b/src/app/components/app/AppError.vue
@@ -89,11 +89,12 @@
                 <h2 :id="templateIdDetails">{{ t('details') }}</h2>
                 <div>
                   <span class="font-bold">
-                    {{ error.statusText }}
+                    {{ statusName }}
                   </span>
-                  <!-- eslint-disable vue/no-v-html -->
-                  <div v-if="error.stack" v-html="error.stack" />
-                  <!-- eslint-enable vue/no-v-html -->
+                  <pre
+                    v-if="isDev && error.stack"
+                    class="overflow-x-auto whitespace-pre-wrap"
+                    >{{ error.stack }}</pre>
                 </div>
               </section>
             </Card>
@@ -144,6 +145,7 @@ const { t } = useI18n()
 const localePath = useLocalePath()
 const detailsIsOpen = ref<boolean>()
 const templateIdDetails = useId()
+const isDev = import.meta.dev
 </script>
 
 <i18n lang="yaml">


### PR DESCRIPTION
The technical details panel on the error page always showed an empty status line and stack trace, because `error.statusText` is never set by any of our error-construction call sites and Nuxt strips `.stack` during SSR payload serialization. This swaps in the already-computed localized `statusName`, and makes stack-trace display an explicit dev-only gate instead of relying on that serialization quirk, replacing the unsafe `v-html` render with a plain-text `<pre>` block since stack traces aren't HTML.