### PR TITLE
fix(urql): reset client when clearing cache

### DIFF
--- a/src/app/pages/session/view/index.vue
+++ b/src/app/pages/session/view/index.vue
@@ -344,7 +344,7 @@ defineRouteRules({
   robots: false,
 })
 
-const { $urqlCache } = useNuxtApp()
+const { $urqlCache, $urqlReset } = useNuxtApp()
 const { t } = useI18n()
 const requestEvent = useRequestEvent()
 const store = useStore()
@@ -371,7 +371,8 @@ const apiClientCacheClear = async () => {
     return
   }
 
-  toast.promise($urqlCache.clear(), {
+  // Resetting rebuilds the clients on a fresh in-memory store, whereas clearing the storage alone would leave the running offline exchange serving and re-persisting the entities it still holds.
+  toast.promise($urqlReset(), {
     error: () => t('apiClientCacheClearError'),
     success: () => t('apiClientCacheClearSuccess'),
   })

--- a/src/shared/utils/urql.ts
+++ b/src/shared/utils/urql.ts
@@ -393,14 +393,28 @@ export const getUrqlClient = async ({
   const client = ref(createClient(initial.clientOptions))
   const clientTesting = ref(createClient(initial.clientOptionsTesting))
 
-  const urqlReset = async () => {
-    // Drop persisted entities first so the rebuilt exchange below starts
-    // from an empty store instead of rehydrating the previous session's data.
+  const urqlResetInThisTab = async () => {
+    // Drop persisted entities first so the rebuilt exchange below starts from an empty store instead of rehydrating the previous session's data.
     await cacheStorage?.clear()
 
     const next = buildClientOptions()
     client.value = createClient(next.clientOptions)
     clientTesting.value = createClient(next.clientOptionsTesting)
+  }
+
+  // Every tab holds its own in-memory store and writes it back to the shared storage on its next persist, so a reset that stops at the tab it was triggered in gets undone by the others.
+  const resetChannel = import.meta.client
+    ? new BroadcastChannel('urql-reset')
+    : undefined
+
+  resetChannel?.addEventListener('message', () => {
+    void urqlResetInThisTab()
+  })
+
+  const urqlReset = async () => {
+    // `postMessage` reaches the other tabs only, never the sender, so this tab still has to reset itself below.
+    resetChannel?.postMessage(undefined)
+    await urqlResetInThisTab()
   }
 
   return {


### PR DESCRIPTION
The "clear cache" button in the session settings called the graphcache storage's `clear()`, which wipes the persisted entries in IndexedDB but leaves the offline exchange's in-memory normalized store untouched. The tab kept answering queries from the entities it still held, and wrote them back on its next persist, so the cache appeared to survive being cleared.

The button now calls `$urqlReset()`, which clears the storage and rebuilds the clients so `getOfflineExchange` binds a fresh, empty store. This is the same path already used by login and JWT refresh.

Because every tab keeps its own in-memory store, a reset confined to one tab still gets undone as soon as another tab persists what it holds. `$urqlReset()` therefore announces itself on a `BroadcastChannel` and every tab resets on receipt, which also means logging in or out in one tab no longer leaves the previous session's entities cached in the others.