### PR TITLE
fix(account): validate the password asynchronously on submit

### DIFF
--- a/src/app/components/form/account/password/FormAccountPasswordChange.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordChange.vue
@@ -116,7 +116,7 @@ const form = useForm({
     passwordNew: '',
   },
   validators: {
-    onSubmit: formSchema,
+    onSubmitAsync: formSchema,
   },
   onSubmit: async ({ value }) => {
     const result = await accountPasswordChangeMutation.executeMutation({

--- a/src/app/components/form/account/password/FormAccountPasswordReset.vue
+++ b/src/app/components/form/account/password/FormAccountPasswordReset.vue
@@ -93,7 +93,7 @@ const form = useForm({
     passwordConfirm: '',
   },
   validators: {
-    onSubmit: formSchema,
+    onSubmitAsync: formSchema,
   },
   onSubmit: async ({ value }) => {
     const result = await passwordResetMutation.executeMutation({

--- a/src/app/components/form/account/registration/FormAccountRegistration.vue
+++ b/src/app/components/form/account/registration/FormAccountRegistration.vue
@@ -75,7 +75,7 @@ const form = useForm({
     passwordRepetition: '',
   },
   validators: {
-    onSubmit: formSchema,
+    onSubmitAsync: formSchema,
   },
   onSubmit: async ({ value }) => {
     emit('submit', {


### PR DESCRIPTION
Submitting the registration, password reset, or password change form threw `Uncaught (in promise) Error: async function passed to sync validator` instead of validating.

The password schema refines with the zxcvbn strength score, which is loaded on demand and therefore asynchronous.
Any object schema embedding it returns a promise from its standard-schema validation, and TanStack Form's synchronous `onSubmit` validator explicitly throws on that.
The three forms now pass their schema to `onSubmitAsync`, which form core awaits before running the submit handler, with no debounce for the submit cause.

Verified against the installed form core that the synchronous validator reproduces the error, that the asynchronous one keeps a weak password from reaching the submit handler, and that a strong password still submits.
This matters most for the password reset form, whose submit handler performs the mutation.
